### PR TITLE
Add CalEnviroScreen color-coded metrics

### DIFF
--- a/style.css
+++ b/style.css
@@ -234,6 +234,14 @@ button:focus-visible {
   font-size: 0.9rem;
 }
 
+.ces-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
 /* Accessibility */
 .visually-hidden {
   position: absolute !important;


### PR DESCRIPTION
## Summary
- color helper and section for CalEnviroScreen percentiles with decile-based badges
- add badge styling for CalEnviroScreen values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a248d509ec8327ae97bc2990feb56a