### PR TITLE
Expand demographic report with detailed metrics

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,18 +6,18 @@
 :root {
   --brand-900: #0b3c5d;
   --brand-700: #155b8a;
-  --brand:     #1d65a6;
+  --brand: #1d65a6;
   --brand-600: #165a96;
 
   --ink-900: #0f172a;
-  --ink:     #1f2a37;
-  --muted:   #5b6b7b;
+  --ink: #1f2a37;
+  --muted: #5b6b7b;
 
-  --surface:   #ffffff;
-  --bg:        #f6f9fc;
+  --surface: #ffffff;
+  --bg: #f6f9fc;
   --accent-bg: #eef5fc;
 
-  --border:        #e2e8f0;
+  --border: #e2e8f0;
   --border-strong: #cbd5e1;
 
   --success: #0f766e;
@@ -38,11 +38,29 @@
 /* =========================
    Global Resets
    ========================= */
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
 
 body {
-  font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    sans-serif;
   background: linear-gradient(135deg, #e9f5ff 0%, var(--bg) 100%);
   color: var(--ink);
   line-height: 1.6;
@@ -51,14 +69,25 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+p + p {
+  margin-top: var(--space-4);
+}
 
-p + p { margin-top: var(--space-4); }
-
-.stack { --stack-space: var(--space-4); }
-.stack > * + * { margin-block-start: var(--stack-space); }
-.stack--lg  { --stack-space: var(--space-5); }
-.stack--xl  { --stack-space: var(--space-6); }
-.stack--xxl { --stack-space: calc(var(--space-6) + 8px); }
+.stack {
+  --stack-space: var(--space-4);
+}
+.stack > * + * {
+  margin-block-start: var(--stack-space);
+}
+.stack--lg {
+  --stack-space: var(--space-5);
+}
+.stack--xl {
+  --stack-space: var(--space-6);
+}
+.stack--xxl {
+  --stack-space: calc(var(--space-6) + 8px);
+}
 
 /* =========================
    Container + Layout
@@ -77,7 +106,7 @@ h1 {
   margin: 0;
   font-size: clamp(24px, 2.4vw, 32px);
   font-weight: 800;
-  letter-spacing: .1px;
+  letter-spacing: 0.1px;
   color: var(--brand-900);
 }
 
@@ -95,7 +124,10 @@ h1 {
   align-items: start;
   margin-top: var(--space-5);
 }
-.sticky { position: sticky; top: 16px; }
+.sticky {
+  position: sticky;
+  top: 16px;
+}
 
 /* =========================
    Controls (Search)
@@ -115,15 +147,18 @@ input[type="text"] {
   background: var(--surface);
   font-size: 15px;
   color: var(--ink);
-  transition: border-color .15s ease, box-shadow .15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
-input[type="text"]::placeholder { color: #98a2b3; }
+input[type="text"]::placeholder {
+  color: #98a2b3;
+}
 input[type="text"]:focus {
   outline: none;
   border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(29,101,166,0.15);
+  box-shadow: 0 0 0 3px rgba(29, 101, 166, 0.15);
 }
-
 
 button {
   display: inline-block;
@@ -134,12 +169,22 @@ button {
   border-radius: 10px;
   cursor: pointer;
   font-weight: 700;
-  letter-spacing: .2px;
-  transition: background-color .15s ease, transform .05s ease, box-shadow .15s ease;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.1);
+  letter-spacing: 0.2px;
+  transition:
+    background-color 0.15s ease,
+    transform 0.05s ease,
+    box-shadow 0.15s ease;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 1px 3px rgba(0, 0, 0, 0.1);
 }
-button:hover { background: var(--brand-600); box-shadow: 0 2px 6px rgba(0,0,0,0.15); }
-button:active { transform: translateY(1px); }
+button:hover {
+  background: var(--brand-600);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+button:active {
+  transform: translateY(1px);
+}
 button:focus-visible {
   outline: 2px solid var(--brand);
   outline-offset: 2px;
@@ -148,7 +193,9 @@ button:focus-visible {
 /* =========================
    Result Card + Components
    ========================= */
-.result-box { margin-top: 0; }
+.result-box {
+  margin-top: 0;
+}
 
 .card {
   background: var(--accent-bg);
@@ -185,7 +232,16 @@ button:focus-visible {
   font-weight: 800;
   color: var(--brand-900);
 }
-.section-block + .section-block { margin-top: var(--space-5); }
+.section-block + .section-block {
+  margin-top: var(--space-5);
+}
+
+.sub-section-header {
+  margin: var(--space-3) 0 var(--space-1) 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--brand-900);
+}
 
 .kv {
   display: grid;
@@ -193,8 +249,15 @@ button:focus-visible {
   gap: var(--space-2) var(--space-4);
   margin: var(--space-3) 0 var(--space-4) 0;
 }
-.kv .key { color: var(--muted); font-weight: 700; line-height: 1.5; }
-.kv .val { color: var(--ink); line-height: 1.6; }
+.kv .key {
+  color: var(--muted);
+  font-weight: 700;
+  line-height: 1.5;
+}
+.kv .val {
+  color: var(--ink);
+  line-height: 1.6;
+}
 
 .callout {
   margin: var(--space-3) 0 var(--space-4) 0;
@@ -215,7 +278,11 @@ button:focus-visible {
   font-size: 13px;
 }
 
-.note { color: var(--muted); font-size: 13px; margin-top: var(--space-2); }
+.note {
+  color: var(--muted);
+  font-size: 13px;
+  margin-top: var(--space-2);
+}
 
 .link-row {
   display: grid;
@@ -245,18 +312,33 @@ button:focus-visible {
 /* Accessibility */
 .visually-hidden {
   position: absolute !important;
-  height: 1px; width: 1px;
-  overflow: hidden; clip: rect(1px, 1px, 1px, 1px);
-  white-space: nowrap; clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+  clip-path: inset(50%);
 }
 
 /* Responsive */
 @media (max-width: 980px) {
-  .page-grid { grid-template-columns: 1fr; }
-  .sticky { position: static; top: auto; }
-  .kv { grid-template-columns: 1fr; }
-  .card__header { flex-direction: column; align-items: flex-start; }
+  .page-grid {
+    grid-template-columns: 1fr;
+  }
+  .sticky {
+    position: static;
+    top: auto;
+  }
+  .kv {
+    grid-template-columns: 1fr;
+  }
+  .card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 @media (max-width: 520px) {
-  .link-row { grid-template-columns: 1fr; }
+  .link-row {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- Display additional demographics including race, housing, education, and poverty counts
- Expose detailed CalEnviroScreen indicators and environmental hardship tags
- Add 10‑mile area comparison and sub-section styling for nested CalEnviroScreen data

## Testing
- `npx prettier --check script.js style.css`


------
https://chatgpt.com/codex/tasks/task_e_68a2507946c48327bc63439fa8fdeaac