### PR TITLE
Add PDF export and improved styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBSLprmo1jaNX4wrG4N1Ipgg7-QPrLV97U&libraries=places"></script>
   <!-- Charts -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- Client-side PDF generation -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 </head>
 <body>
   <div class="container">

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ function printReport() {
   window.print();
 }
 
-function downloadReport() {
+function downloadRawData() {
   if (!lastReport) return;
   const blob = new Blob([JSON.stringify(lastReport, null, 2)], {
     type: "application/json",
@@ -28,6 +28,23 @@ function downloadReport() {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+function downloadPdf() {
+  if (!lastReport) return;
+  const safe = (lastReport.address || "report")
+    .replace(/[^a-z0-9]+/gi, "_")
+    .toLowerCase();
+  const element = document.querySelector("#result .card");
+  if (!element) return;
+  const opt = {
+    margin: 0.5,
+    filename: `calwep_report_${safe}.pdf`,
+    image: { type: "jpeg", quality: 0.98 },
+    html2canvas: { scale: 2 },
+    jsPDF: { unit: "in", format: "letter", orientation: "portrait" },
+  };
+  html2pdf().set(opt).from(element).save();
 }
 
 function shareReport() {
@@ -432,13 +449,6 @@ function renderResult(address, data, elapsedMs) {
     </section>
   `;
 
-  const rawJsonSection = `
-    <section class="section-block">
-      <h3 class="section-header">Raw data</h3>
-      <pre class="raw-json">${escapeHTML(JSON.stringify(data, null, 2))}</pre>
-    </section>
-  `;
-
   const localInfo = `
     <section class="section-block">
       <h3 class="section-header">Location summary</h3>
@@ -500,7 +510,6 @@ function renderResult(address, data, elapsedMs) {
           : `<p class="note">No active alerts found for this location.</p>`
       }
     </section>
-    ${rawJsonSection}
   `;
 
   document.getElementById("result").innerHTML = `
@@ -510,7 +519,8 @@ function renderResult(address, data, elapsedMs) {
           <h2 class="card__title">Results for: ${escapeHTML(address)}</h2>
           <div class="card__actions">
             <button type="button" onclick="printReport()">Print</button>
-            <button type="button" onclick="downloadReport()">Download</button>
+            <button type="button" onclick="downloadPdf()">Download PDF</button>
+            <button type="button" onclick="downloadRawData()">Raw Data</button>
             <button type="button" onclick="shareReport()">Share Link</button>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -198,7 +198,7 @@ button:focus-visible {
 }
 
 .card {
-  background: var(--accent-bg);
+  background: linear-gradient(135deg, var(--accent-bg) 0%, #ffffff 100%);
   border: 1px solid var(--border);
   border-left: 4px solid var(--brand);
   border-radius: 12px;
@@ -250,7 +250,17 @@ button:focus-visible {
   font-size: 1.05rem;
   font-weight: 800;
   color: var(--brand-900);
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 4px;
 }
+
+.section-block {
+  background: #fff;
+  padding: var(--space-4);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
 .section-block + .section-block {
   margin-top: var(--space-5);
 }
@@ -329,6 +339,15 @@ button:focus-visible {
   background: #fff;
   margin-right: 6px;
   font-size: 0.9rem;
+}
+
+.map-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin-top: var(--space-4);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-elev);
 }
 
 .ces-badge {


### PR DESCRIPTION
## Summary
- Enable PDF downloads of the generated report
- Add button to download raw data and remove raw JSON section
- Polish layout and styling, including map responsiveness

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a261ea991883279bbc9e30044b04b3