### PR TITLE
Add water district and expanded 10‑mile data

### DIFF
--- a/style.css
+++ b/style.css
@@ -310,7 +310,7 @@ button:focus-visible {
 
 .comparison-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: var(--space-6);
   margin-top: var(--space-5);
 }


### PR DESCRIPTION
## Summary
- render Enviroscreen data via reusable helper
- show demographics and environmental metrics for surrounding 10‑mile area
- include water district‑wide demographics and environment; support 3‑column layout

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c335be68832793462b30c5885db6