### PR TITLE
Remove redundant 'Census Tract' prefix in surrounding list

### DIFF
--- a/script.js
+++ b/script.js
@@ -262,7 +262,8 @@ async function enrichSurrounding(data = {}) {
         .then((j) => {
           const names = (j.features || [])
             .map((f) => f.attributes?.NAME)
-            .filter(Boolean);
+            .filter(Boolean)
+            .map((n) => n.replace(/^Census Tract\s+/i, ""));
           s.census_tracts = Array.from(new Set(names)).slice(0, 10);
         })
         .catch(() => {})


### PR DESCRIPTION
## Summary
- Strip the `Census Tract` prefix from census tract listings in the surrounding 10-mile area

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ca73f0f483279aed6429db829ed6