### PR TITLE
Refactor results layout into section rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -326,6 +326,14 @@ button:focus-visible {
   min-width: 0;
 }
 
+.column-headers .col {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: center;
+  font-weight: 700;
+}
+
 .callout {
   margin: var(--space-3) 0 var(--space-4) 0;
   padding: 12px 14px;


### PR DESCRIPTION
## Summary
- Render location, population, language, race, housing, DAC, environment, hardships, and alerts with census tract, 10-mile radius, and water district columns
- Add reusable helper for building comparison rows and column headers
- Style column headers for new side-by-side layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d47f9028832789a3e6a40d43d876