### PR TITLE
Highlight DAC population and tract percentages

### DIFF
--- a/script.js
+++ b/script.js
@@ -1618,15 +1618,26 @@ function renderResult(address, data, elapsedMs) {
   const dacCallout = (status, tracts, popPct, tractPct) => {
     const yes = Array.isArray(tracts) ? tracts.length > 0 : !!status;
     const border = yes ? "var(--success)" : "var(--border-strong)";
-    const list =
-      Array.isArray(tracts) && tracts.length
-        ? ` — Tracts ${tracts.map((t) => escapeHTML(t)).join(", ")}`
-        : "";
-    const parts = [];
-    if (Number.isFinite(popPct)) parts.push(`${fmtPct(popPct)} population`);
-    if (Number.isFinite(tractPct)) parts.push(`${fmtPct(tractPct)} of tracts`);
-    const extra = parts.length ? ` (${parts.join(", ")})` : "";
-    return `<div class="callout" style="border-left-color:${border}">Disadvantaged community: <strong>${yes ? "Yes" : "No"}</strong>${list}${extra}</div>`;
+
+    const lines = [
+      `Disadvantaged community: <strong>${yes ? "Yes" : "No"}</strong>`,
+    ];
+
+    const stats = [];
+    if (Number.isFinite(popPct))
+      stats.push(`<li><strong>${fmtPct(popPct)}</strong> of population</li>`);
+    if (Number.isFinite(tractPct))
+      stats.push(`<li><strong>${fmtPct(tractPct)}</strong> of tracts</li>`);
+    if (stats.length) lines.push(`<ul class="dac-stats">${stats.join("")}</ul>`);
+
+    if (Array.isArray(tracts) && tracts.length)
+      lines.push(
+        `<div class="dac-tracts">Tracts ${tracts
+          .map((t) => escapeHTML(t))
+          .join(", ")}</div>`,
+      );
+
+    return `<div class="callout" style="border-left-color:${border}">${lines.join("")}</div>`;
   };
 
   const dacRow = buildComparisonRow(

--- a/style.css
+++ b/style.css
@@ -341,8 +341,22 @@ button:focus-visible {
   border: 1px dashed var(--border);
   border-left: 4px solid var(--warning);
   border-radius: 10px;
-  font-weight: 700;
+  font-weight: 400;
   color: var(--ink-900);
+}
+
+.dac-stats {
+  margin: var(--space-2) 0 0 1.2em;
+  padding: 0;
+  list-style: disc;
+}
+
+.dac-stats li {
+  margin: 2px 0;
+}
+
+.dac-tracts {
+  margin-top: var(--space-2);
 }
 
 .updated--footer {


### PR DESCRIPTION
## Summary
- Emphasize DAC population and tract percentages with bullet points and bold styling
- Adjust callout styling and add dedicated CSS classes for DAC stats

## Testing
- `npm test` (fails: package.json missing)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8f2acf81c8327ab92d426de99e89d