### PR TITLE
Hard-code water district environmental indicators

### DIFF
--- a/script.js
+++ b/script.js
@@ -782,6 +782,44 @@ async function enrichWaterDistrict(data = {}, address = "") {
   if (census_tract) tracts.unshift(String(census_tract));
   w.census_tracts = [...new Set(tracts)];
 
+  // Hard-coded CalEnviroScreen indicators for the water district region
+  w.environment = {
+    percentile: 48.5,
+    overall_percentiles: {
+      pollution_burden: 37.2,
+      population_characteristics: 56.5,
+    },
+    exposures: {
+      ozone: 98.8,
+      pm25: 34.0,
+      diesel: 24.2,
+      toxic_releases: 32.7,
+      traffic: 12.3,
+      pesticides: 22.7,
+      drinking_water: 61.8,
+      lead: 49.1,
+    },
+    environmental_effects: {
+      cleanup_sites: 25.2,
+      groundwater_threats: 20.4,
+      hazardous_waste: 27.8,
+      impaired_waters: 23.0,
+      solid_waste: 45.7,
+    },
+    sensitive_populations: {
+      asthma: 58.9,
+      low_birth_weight: 52.8,
+      cardiovascular_disease: 81.6,
+    },
+    socioeconomic_factors: {
+      education: 45.5,
+      linguistic_isolation: 17.0,
+      poverty: 54.5,
+      unemployment: 63.2,
+      housing_burden: 38.8,
+    },
+  };
+
   return { ...data, water_district: w };
 }
 


### PR DESCRIPTION
## Summary
- Populate water district results with fixed CalEnviroScreen metrics for environmental indicators

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2d33f3c8327a7270e2508d0f939