### PR TITLE
Move CyberWiz credit to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="description" content="Community Insights Tool helps water agency staff explore demographics, languages, and environmental conditions." />
-  <title>Community Insights Tool - powered by CyberWiz</title>
+  <title>Community Insights Tool</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
@@ -18,7 +18,7 @@
 <body>
   <div class="container">
     <header class="page-header stack stack--xl">
-      <h1>Community Insights Tool - <a href="https://cyberwiz.io" target="_blank" rel="noopener noreferrer">powered by CyberWiz</a></h1>
+      <h1>Community Insights Tool</h1>
       <p class="tagline">Turn any address into a snapshot of community needs and priorities.</p>
       <p class="description">The Community Insights Tool helps water agency staff understand the unique communities they serve. By entering an address, you can explore neighborhood-level demographics, languages spoken, and environmental conditions, and see how that location compares to the broader service area. This tool combines U.S. Census (ACS) data with CalEPA Enviroscreen to support effective outreach, grant applications, and equitable program design.</p>
       <div class="quick-instructions">
@@ -46,6 +46,10 @@
       <div id="result" class="result-box" aria-live="polite" aria-atomic="true"></div>
     </main>
   </div>
+
+  <footer class="page-footer">
+    <p>Powered by <a href="https://cyberwiz.io" target="_blank" rel="noopener noreferrer">CyberWiz</a></p>
+  </footer>
 
   <script src="script.js" defer></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -119,6 +119,25 @@ h1 {
   color: var(--ink);
 }
 
+.page-footer {
+  text-align: center;
+  margin-top: var(--space-6);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.page-footer a {
+  color: var(--brand-700);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.page-footer a:hover {
+  text-decoration: underline;
+}
+
 .quick-instructions ol {
   margin-top: var(--space-2);
   padding-left: var(--space-5);


### PR DESCRIPTION
## Summary
- Move "Powered by CyberWiz" from page header to a dedicated footer
- Style footer with subtle top border, centered muted text for a more professional appearance
- Update page title to remove CyberWiz reference

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7e441ac8327850b062f6e014bb0