### PR TITLE
fix: ensure water agency name populated

### DIFF
--- a/script.js
+++ b/script.js
@@ -802,7 +802,12 @@ async function enrichWaterDistrict(data = {}, address = "") {
     tasks.push(
       fetchJsonWithDiagnostics(url)
         .then((j) => {
-          w.name = j?.agency?.agency_name || w.name;
+          w.name =
+            j?.agency?.agency_name ||
+            j?.agency?.name ||
+            j?.agency_name ||
+            j?.name ||
+            w.name;
           const tracts =
             j?.agency?.service_area_tracts ||
             j?.service_area_tracts ||


### PR DESCRIPTION
## Summary
- handle alternative property names from lookup service so water agency name isn't null

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fb0a691483279f7535c61aa9fe74