### PR TITLE
fix: point API requests to nftapi.cyberwiz.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <!-- Point the frontend at the correct API host -->
-  <meta name="api-base" content="https://calwep-nft-api.onrender.com">
+  <meta name="api-base" content="https://nftapi.cyberwiz.io">
   <script src="config.js"></script>
   <!-- Client-side PDF generation -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 /* script.js — Demographics Lookup (API-base aware)
-   - Reads API base from <meta name="api-base"> (https://calwep-nft-api.onrender.com)
+   - Reads API base from <meta name="api-base"> (https://nftapi.cyberwiz.io)
    - Calls GET /demographics?address=...
    - Robust fetch diagnostics, Google Places autocomplete, Enter-to-search, aria-busy
 */
@@ -64,7 +64,7 @@ function shareReport() {
 }
 
 // ---------- Config ----------
-const API_BASE = "https://calwep-nft-api.onrender.com";
+const API_BASE = "https://nftapi.cyberwiz.io";
 const API_PATH = "/demographics"; // see section 2 for why '/api' is safest
 
 // ---------- Utilities ----------


### PR DESCRIPTION
## Summary
- update API base constant to `https://nftapi.cyberwiz.io`
- adjust HTML meta tag to match new API host

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa625e8aac832794c35dcfe3d3cbad