### PR TITLE
Add loading spinner overlay with elapsed time

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,11 @@
     <footer class="page-footer" itemscope itemtype="https://schema.org/Organization">
       <p>Community Insights Tool — Powered by <a href="https://cyberwiz.io" target="_blank" rel="noopener noreferrer" title="CyberWiz – Cybersecurity, SOC 2 Compliance, and Custom Programs" aria-label="CyberWiz: cybersecurity, compliance, and training programs" itemprop="url"><span itemprop="name">CyberWiz</span></a></p>
     </footer>
+  <div id="spinnerOverlay" class="spinner-overlay" style="display: none;">
+    <div class="spinner">
+      <span id="spinnerTime">0m 00s</span>
+    </div>
+  </div>
 
   <script src="script.js" defer></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -190,16 +190,19 @@ function formatDuration(ms = 0) {
 }
 function startSearchTimer() {
   searchTimerStart = Date.now();
-  const el = document.getElementById("searchTimer");
-  if (el) el.textContent = "0m 00s";
+  const setText = (text) => {
+    const timerEl = document.getElementById("searchTimer");
+    if (timerEl) timerEl.textContent = text;
+    const spinnerEl = document.getElementById("spinnerTime");
+    if (spinnerEl) spinnerEl.textContent = text;
+  };
+  setText("0m 00s");
   searchTimerInterval = setInterval(() => {
     if (!searchTimerStart) return;
     const elapsed = Date.now() - searchTimerStart;
     const secs = Math.floor((elapsed / 1000) % 60);
     const mins = Math.floor(elapsed / 60000);
-    const timerEl = document.getElementById("searchTimer");
-    if (timerEl)
-      timerEl.textContent = `${mins}m ${secs.toString().padStart(2, "0")}s`;
+    setText(`${mins}m ${secs.toString().padStart(2, "0")}s`);
   }, 1000);
 }
 function stopSearchTimer() {
@@ -2099,6 +2102,8 @@ async function lookup() {
 
   resultBox.setAttribute("aria-busy", "true");
   renderLoading(address);
+  const overlay = document.getElementById("spinnerOverlay");
+  if (overlay) overlay.style.display = "flex";
   startSearchTimer();
   let elapsed = 0;
 
@@ -2144,6 +2149,8 @@ async function lookup() {
     if (!elapsed) elapsed = stopSearchTimer();
     renderError(String(err), address, elapsed);
   } finally {
+    const overlay = document.getElementById("spinnerOverlay");
+    if (overlay) overlay.style.display = "none";
     resultBox.removeAttribute("aria-busy");
   }
 }

--- a/style.css
+++ b/style.css
@@ -495,3 +495,38 @@ button:focus-visible {
     display: none;
   }
 }
+
+/* Loading spinner overlay */
+.spinner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.2);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.spinner {
+  width: 80px;
+  height: 80px;
+  border: 8px solid var(--border);
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  background: var(--surface);
+  color: var(--brand-900);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- show a centered spinner overlay while lookups run, displaying the elapsed time
- style the spinner overlay and animation
- sync timer updates to both the results card and spinner

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa67940f008327a4811db3a86bdaff