### PR TITLE
Keep spinner text stationary

### DIFF
--- a/style.css
+++ b/style.css
@@ -511,18 +511,29 @@ button:focus-visible {
 }
 
 .spinner {
+  position: relative;
   width: 80px;
   height: 80px;
-  border: 8px solid var(--border);
-  border-top-color: var(--brand);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
   background: var(--surface);
   color: var(--brand-900);
+}
+
+.spinner::before {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 8px solid var(--border);
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary
- Prevent spinner text from rotating by moving the animation to a pseudo-element
- Center spinner time display while keeping spinner ring spinning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa69596ab483279a3e72a8fd026806