### PR TITLE
Add AdMob banner templates for iOS and Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.admob">
+    <application>
+        <!-- Initialize Google Mobile Ads SDK with application ID -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="CookifyAIca-app-pub-4657770701639357~9545690594" />
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/example/admob/MainActivity.kt
+++ b/android/app/src/main/java/com/example/admob/MainActivity.kt
@@ -1,0 +1,38 @@
+package com.example.admob
+
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.MobileAds
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var adView: AdView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val layout = FrameLayout(this)
+        setContentView(layout)
+
+        // Initialize Mobile Ads SDK
+        MobileAds.initialize(this)
+
+        adView = AdView(this).apply {
+            adUnitId = "CookifyAIca-app-pub-4657770701639357/5885517308"
+            setAdSize(AdSize.BANNER)
+        }
+
+        val params = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+        )
+        layout.addView(adView, params)
+
+        val adRequest = AdRequest.Builder().build()
+        adView.loadAd(adRequest)
+    }
+}

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+import GoogleMobileAds
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Initialize Google Mobile Ads SDK
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        return true
+    }
+}

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>GADApplicationIdentifier</key>
+  <string>CookifyAIca-app-pub-4657770701639357~1185453459</string>
+</dict>
+</plist>

--- a/ios/ViewController.swift
+++ b/ios/ViewController.swift
@@ -1,0 +1,23 @@
+import UIKit
+import GoogleMobileAds
+
+class ViewController: UIViewController {
+    private var bannerView: GADBannerView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        bannerView = GADBannerView(adSize: kGADAdSizeBanner)
+        bannerView.adUnitID = "CookifyAIca-app-pub-4657770701639357/6400506715"
+        bannerView.rootViewController = self
+        bannerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bannerView)
+
+        NSLayoutConstraint.activate([
+            bannerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bannerView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+
+        bannerView.load(GADRequest())
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Google Mobile Ads SDK in iOS example with banner ad and app identifier
- add Android example code to initialize SDK and load a banner ad unit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6c98d6c483279bb9b0082f7d15a2