### PR TITLE
Fix water district tract FIPS handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -1030,7 +1030,15 @@ async function enrichWaterDistrict(data = {}, address = "") {
     ? w.census_tracts_fips.map(String)
     : [];
   for (const t of w.census_tracts) {
-    if (/^\d{11}$/.test(t)) fipsList.push(t);
+    if (/^\d{11}$/.test(t)) {
+      fipsList.push(t);
+    } else if (state_fips && county_fips) {
+      const digits = String(t).replace(/[^0-9]/g, "");
+      if (digits) {
+        const tract = digits.padStart(6, "0").slice(-6);
+        fipsList.push(`${state_fips}${county_fips}${tract}`);
+      }
+    }
   }
   if (state_fips && county_fips && tract_code)
     fipsList.unshift(`${state_fips}${county_fips}${tract_code}`);


### PR DESCRIPTION
## Summary
- derive full tract FIPS list for water districts from tract name strings when geometry lookup fails
- ensures district demographics and population reflect all census tracts

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa70ea48e883278c4ec2b5ecbc57d8