### PR TITLE
feat: load Maps API key from secure endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/config.js
+++ b/config.js
@@ -1,2 +1,0 @@
-// Configuration for CalWEP Demographics site
-const GOOGLE_MAPS_KEY = "AIzaSyBSLprmo1jaNX4wrG4N1Ipgg7-QPrLV97U";

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   <link rel="stylesheet" href="style.css" />
   <!-- Point the frontend at the correct API host -->
   <meta name="api-base" content="https://nftapi.cyberwiz.io">
-  <script src="config.js"></script>
   <!-- Client-side PDF generation -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 </head>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "calwep-demographic-website",
+  "version": "1.0.0",
+  "description": "CalWEP Demographic Website",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+const http = require('http');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/maps-key') {
+    const key = process.env.GOOGLE_MAPS_API_KEY;
+    if (!key) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'API key not configured' }));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ key }));
+    return;
+  }
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- remove hard-coded Google Maps key and drop `config.js`
- fetch API key from a new `/api/maps-key` server endpoint
- load Google Maps and static map images using the fetched key

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -s http://localhost:3000/api/maps-key`

------
https://chatgpt.com/codex/tasks/task_e_68aba4e47ef48327b00f4f5c0f6a37ae