### PR TITLE
Add security headers and CSP

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,25 @@
+# Deployment Security Headers
+
+To harden production deployments, serve the application with the following HTTP headers and Content Security Policy (CSP).
+
+## Nginx
+```
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://nftapi.cyberwiz.io https://api.bigdatacloud.net https://geo.fcc.gov https://api.census.gov https://tigerweb.geo.census.gov https://gis.water.ca.gov https://services.arcgis.com https://overpass-api.de https://api.weather.gov https://maps.googleapis.com; img-src 'self' https://maps.googleapis.com data:";
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer" always;
+```
+
+## Apache
+```
+<IfModule mod_headers.c>
+  Header set Content-Security-Policy "default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://nftapi.cyberwiz.io https://api.bigdatacloud.net https://geo.fcc.gov https://api.census.gov https://tigerweb.geo.census.gov https://gis.water.ca.gov https://services.arcgis.com https://overpass-api.de https://api.weather.gov https://maps.googleapis.com; img-src 'self' https://maps.googleapis.com data:" 
+  Header set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+  Header set X-Frame-Options "DENY"
+  Header set X-Content-Type-Options "nosniff"
+  Header set Referrer-Policy "no-referrer"
+</IfModule>
+```
+
+Adjust domains as needed for additional external resources.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="description" content="Community Insights Tool helps water agency staff explore demographics, languages, and environmental conditions." />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://nftapi.cyberwiz.io https://api.bigdatacloud.net https://geo.fcc.gov https://api.census.gov https://tigerweb.geo.census.gov https://gis.water.ca.gov https://services.arcgis.com https://overpass-api.de https://api.weather.gov https://maps.googleapis.com; img-src 'self' https://maps.googleapis.com data:" />
   <title>Community Insights Tool</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" integrity="sha384-jFkr5e7GEFjeV48fa6VnJHKsirpHrwnWNc273b/JrQ9xYl4t8qsMotJpCiiu389X" crossorigin="anonymous">
   <link rel="stylesheet" href="style.css" />
   <!-- Point the frontend at the correct API host -->
   <meta name="api-base" content="https://nftapi.cyberwiz.io">
   <!-- Client-side PDF generation -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha384-Yv5O+t3uE3hunW8uyrbpPW3iw6/5/Y7HitWJBLgqfMoA36NogMmy+8wWZMpn3HWc" crossorigin="anonymous"></script>
 </head>
 <body>
   <div class="container">

--- a/server.js
+++ b/server.js
@@ -2,7 +2,19 @@ const http = require('http');
 
 const port = process.env.PORT || 3000;
 
+const CSP = "default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://nftapi.cyberwiz.io https://api.bigdatacloud.net https://geo.fcc.gov https://api.census.gov https://tigerweb.geo.census.gov https://gis.water.ca.gov https://services.arcgis.com https://overpass-api.de https://api.weather.gov https://maps.googleapis.com; img-src 'self' https://maps.googleapis.com data:";
+const securityHeaders = {
+  'Content-Security-Policy': CSP,
+  'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+};
+
 const server = http.createServer((req, res) => {
+  for (const [k, v] of Object.entries(securityHeaders)) {
+    res.setHeader(k, v);
+  }
   if (req.url === '/api/maps-key') {
     const key = process.env.GOOGLE_MAPS_API_KEY;
     if (!key) {


### PR DESCRIPTION
## Summary
- add Content Security Policy limiting external scripts, styles, fonts, connections, and images
- protect external assets with integrity hashes and crossorigin attributes
- serve Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy headers
- document sample Nginx/Apache rules for deploying these headers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aba6d98d708327ba7af174bed47d04