### PR TITLE
Load Google Maps key from environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MAPS_API_KEY=your_google_maps_api_key

--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ This project helps water agency staff explore neighborhood-level demographics an
   - `node run-axe.js` outputs `axe-report.json` using axe-core.
   - Serve the site locally (`npx http-server -p 8080`) and run `npx lighthouse http://localhost:8080/index.html --chrome-flags="--no-sandbox --headless" --output=json --output-path=lighthouse-report.json`.
 - These audits verify color contrast, keyboard navigation, and ARIA usage per WCAG 2.1.
+
+## Google Maps API Key
+
+The site uses the Google Maps JavaScript API and loads the key from an environment variable.
+
+### Local development
+
+1. Copy `.env.example` to `.env` and set your key:
+   ```bash
+   MAPS_API_KEY=your_google_maps_api_key
+   ```
+2. The server loads this file via [dotenv](https://www.npmjs.com/package/dotenv). The key is exposed to the frontend at `/api/maps-key`.
+3. Start the development server with `npm start`.
+
+### Production (Render, Heroku, etc.)
+
+- In your hosting provider's dashboard, add an environment variable named `MAPS_API_KEY` with your key. The variable is available to the server at runtime; no `.env` file is needed.
+- Do **not** commit real keys to Git. `.env` is already ignored by `.gitignore`.
+
+### Security considerations
+
+- Restrict the Google Maps key to allowed domains/IPs and enable usage quotas in the Google Cloud Console.
+- Monitor usage and regenerate the key if it becomes compromised.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/browser": "^10.5.0",
         "@sentry/node": "^7.120.1",
         "dompurify": "^3.0.6",
+        "dotenv": "^16.6.1",
         "html2pdf.js": "^0.11.1"
       },
       "devDependencies": {
@@ -1870,6 +1871,18 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@sentry/browser": "^10.5.0",
     "@sentry/node": "^7.120.1",
     "html2pdf.js": "^0.11.1",
-    "dompurify": "^3.0.6"
+    "dompurify": "^3.0.6",
+    "dotenv": "^16.6.1"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const zlib = require('zlib');
 const Sentry = require('@sentry/node');
+require('dotenv').config();
 
 const port = process.env.PORT || 3000;
 
@@ -43,7 +44,7 @@ const server = http.createServer((req, res) => {
     res.setHeader(k, v);
   }
   if (req.url === '/api/maps-key') {
-    const key = process.env.GOOGLE_MAPS_API_KEY;
+    const key = process.env.MAPS_API_KEY;
     if (!key) {
       compressAndSend(
         req,

--- a/src/maps.js
+++ b/src/maps.js
@@ -2,6 +2,7 @@ import { monitorAsync } from "./api.js";
 
 let autocomplete = null;
 let googleMapsKey = "";
+// Cache the promise so we only hit the endpoint once per session
 let mapsKeyPromise = null;
 
 export function getGoogleMapsKey() {


### PR DESCRIPTION
## Summary
- serve Google Maps API key from `process.env.MAPS_API_KEY` via `/api/maps-key`
- frontend fetches key once and caches it before loading Google Maps script
- document local `.env` setup, production environment variable configuration, and key security tips

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abcaa1887883278854a73119a6a6ca