### PR TITLE
Remove SRI from Google Fonts link to prevent load failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
       rel="stylesheet"
-      integrity="sha384-jFkr5e7GEFjeV48fa6VnJHKsirpHrwnWNc273b/JrQ9xYl4t8qsMotJpCiiu389X"
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
## Summary
- ensure Inter font loads by removing a hard-coded SRI hash that blocked Google Fonts responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd4e133a48327ac5aeb396a87f1b9