### PR TITLE
feat: use local MAPS_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Environment variables can be read from the local machine in many languages:
 
 - **JavaScript**
   ```js
-  const mapsApiKey = import.meta.env.MAPS_API_KEY;
+  const mapsApiKey =
+    import.meta.env.MAPS_API_KEY || import.meta.env.VITE_MAPS_API_KEY;
   ```
 - **Python**
   ```python

--- a/dist/maps.js
+++ b/dist/maps.js
@@ -1,1 +1,61 @@
-let l=null;const p="your_google_maps_api_key",r=p;function m(){const e=document.getElementById("autocomplete");!e||typeof google>"u"||!google.maps||(l=new google.maps.places.Autocomplete(e,{types:["address"],componentRestrictions:{country:"us"},fields:["address_components","formatted_address"]}),l.addListener("place_changed",()=>{const o=l.getPlace();let n="",c="",i="",a="";for(const t of o.address_components||[]){const s=t.types||[];s.includes("street_number")?n=t.long_name+" ":s.includes("route")?n+=t.long_name:s.includes("locality")?c=t.long_name:s.includes("administrative_area_level_1")?i=t.short_name:s.includes("postal_code")&&(a=t.long_name)}if(!a&&o.formatted_address){const t=o.formatted_address.match(/\b\d{5}(?:-\d{4})?\b/);t&&(a=t[0])}const d=[n.trim(),c,i,a].filter(Boolean);d.length&&(e.value=d.join(", "))}),e.addEventListener("keydown",o=>{var n;o.key==="Enter"&&(o.preventDefault(),(n=document.getElementById("lookupBtn"))==null||n.click())}))}async function u(){try{const e=document.createElement("script");e.src=`https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(r)}&libraries=places&callback=initAutocomplete`,e.async=!0,document.head.appendChild(e)}catch(e){console.error("Failed to load Google Maps",e)}}window.initAutocomplete=m;export{r as G,u as l};
+let a = null;
+const p = "".trim(),
+  d = p;
+function m() {
+  const e = document.getElementById("autocomplete");
+  !e ||
+    typeof google > "u" ||
+    !google.maps ||
+    ((a = new google.maps.places.Autocomplete(e, {
+      types: ["address"],
+      componentRestrictions: { country: "us" },
+      fields: ["address_components", "formatted_address"],
+    })),
+    a.addListener("place_changed", () => {
+      const o = a.getPlace();
+      let n = "",
+        c = "",
+        i = "",
+        l = "";
+      for (const t of o.address_components || []) {
+        const s = t.types || [];
+        s.includes("street_number")
+          ? (n = t.long_name + " ")
+          : s.includes("route")
+            ? (n += t.long_name)
+            : s.includes("locality")
+              ? (c = t.long_name)
+              : s.includes("administrative_area_level_1")
+                ? (i = t.short_name)
+                : s.includes("postal_code") && (l = t.long_name);
+      }
+      if (!l && o.formatted_address) {
+        const t = o.formatted_address.match(/\b\d{5}(?:-\d{4})?\b/);
+        t && (l = t[0]);
+      }
+      const r = [n.trim(), c, i, l].filter(Boolean);
+      r.length && (e.value = r.join(", "));
+    }),
+    e.addEventListener("keydown", (o) => {
+      var n;
+      o.key === "Enter" &&
+        (o.preventDefault(),
+        (n = document.getElementById("lookupBtn")) == null || n.click());
+    }));
+}
+async function u() {
+  if (!d) {
+    console.error("Google Maps API key not configured");
+    return;
+  }
+  try {
+    const e = document.createElement("script");
+    ((e.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(d)}&libraries=places&callback=initAutocomplete`),
+      (e.async = !0),
+      document.head.appendChild(e));
+  } catch (e) {
+    console.error("Failed to load Google Maps", e);
+  }
+}
+window.initAutocomplete = m;
+export { d as G, u as l };

--- a/src/maps.js
+++ b/src/maps.js
@@ -1,5 +1,12 @@
 let autocomplete = null;
-const mapsApiKey = import.meta.env.MAPS_API_KEY || "";
+const mapsApiKey = (
+  import.meta.env.MAPS_API_KEY ||
+  import.meta.env.VITE_MAPS_API_KEY ||
+  ""
+)
+  .toString()
+  .trim();
+
 export const GOOGLE_MAPS_KEY = mapsApiKey;
 
 export function initAutocomplete() {
@@ -45,10 +52,15 @@ export function initAutocomplete() {
 }
 
 export async function loadGoogleMaps() {
+  if (!GOOGLE_MAPS_KEY) {
+    console.error("Google Maps API key not configured");
+    return;
+  }
   try {
-    if (!GOOGLE_MAPS_KEY) throw new Error("Google Maps API key not configured");
     const script = document.createElement("script");
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(GOOGLE_MAPS_KEY)}&libraries=places&callback=initAutocomplete`;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(
+      GOOGLE_MAPS_KEY,
+    )}&libraries=places&callback=initAutocomplete`;
     script.async = true;
     document.head.appendChild(script);
   } catch (err) {


### PR DESCRIPTION
## Summary
- load Google Maps using `MAPS_API_KEY`/`VITE_MAPS_API_KEY` without hitting `/api/maps-key`
- document how to access the key in code

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abdf55a5688327a7f6770d8d33fa89