### PR TITLE
feat: proxy autocomplete to backend

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,9 +74,8 @@
               autocomplete="off"
               inputmode="search"
               aria-label="Address search"
-              list="autocomplete-list"
             />
-            <datalist id="autocomplete-list"></datalist>
+            <ul id="autocomplete-list" class="autocomplete-list"></ul>
             <button id="lookupBtn" type="button" aria-label="Lookup demographics">
             Lookup
           </button>

--- a/src/maps.js
+++ b/src/maps.js
@@ -1,41 +1,128 @@
+// Autocomplete logic for the address search box.
+// All requests are proxied through the backend; the frontend never
+// communicates with Google or embeds an API key.
+
 export function setupAutocomplete() {
   const input = document.getElementById("autocomplete");
   const list = document.getElementById("autocomplete-list");
   if (!input || !list) return;
 
-  // Fetch address suggestions from the server-side proxy
-  input.addEventListener("input", async () => {
+  // Backend endpoint for autocomplete suggestions. Update here if the
+  // server route changes.
+  const AUTOCOMPLETE_ENDPOINT = "/api/autocomplete";
+
+  let debounceId = null;
+  let suggestions = [];
+  let activeIndex = -1;
+
+  const clearSuggestions = (message = "") => {
+    list.innerHTML = message;
+    list.style.display = message ? "block" : "none";
+    suggestions = [];
+    activeIndex = -1;
+  };
+
+  const highlightMatch = (text, query) => {
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(escaped, "gi");
+    return text.replace(regex, (m) => `<strong>${m}</strong>`);
+  };
+
+  const renderSuggestions = (preds, query) => {
+    suggestions = preds;
+    list.innerHTML = preds
+      .map(
+        (p, i) =>
+          `<li class="autocomplete-item" data-index="${i}" role="option">${highlightMatch(
+            p.description,
+            query,
+          )}</li>`,
+      )
+      .join("");
+    list.style.display = "block";
+    updateActive();
+  };
+
+  const selectSuggestion = (index) => {
+    const item = suggestions[index];
+    if (!item) return;
+    input.value = item.description;
+    clearSuggestions();
+    input.focus();
+  };
+
+  const updateActive = () => {
+    const items = list.querySelectorAll(".autocomplete-item");
+    items.forEach((el, idx) => {
+      el.classList.toggle("active", idx === activeIndex);
+    });
+  };
+
+  input.addEventListener("input", () => {
     const query = input.value.trim();
-    if (query.length < 3) {
-      list.innerHTML = "";
+    clearTimeout(debounceId);
+    if (!query) {
+      clearSuggestions();
       return;
     }
-    try {
-      const resp = await fetch(
-        `/api/autocomplete?input=${encodeURIComponent(query)}`,
-      );
-      if (!resp.ok) throw new Error("Autocomplete request failed");
-      const data = await resp.json();
-      const predictions = Array.isArray(data.predictions)
-        ? data.predictions
-        : [];
-      list.innerHTML = "";
-      for (const p of predictions.slice(0, 5)) {
-        const opt = document.createElement("option");
-        opt.value = p.description;
-        list.appendChild(opt);
+
+    // TODO: show a loading spinner while fetching suggestions
+    debounceId = setTimeout(async () => {
+      try {
+        const resp = await fetch(
+          `${AUTOCOMPLETE_ENDPOINT}?input=${encodeURIComponent(query)}`,
+        );
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        const preds = Array.isArray(data.predictions) ? data.predictions : [];
+        if (!preds.length) {
+          clearSuggestions(
+            '<li class="no-suggestions">No suggestions found.</li>',
+          );
+          return;
+        }
+        renderSuggestions(preds, query);
+      } catch (err) {
+        console.error("Autocomplete error", err);
+        clearSuggestions('<li class="error">Unable to fetch suggestions</li>');
       }
-    } catch (err) {
-      console.error("Autocomplete error", err);
-      list.innerHTML = "";
+    }, 300); // Debounce to reduce server calls
+  });
+
+  list.addEventListener("mousedown", (e) => {
+    const item = e.target.closest(".autocomplete-item");
+    if (!item) return;
+    selectSuggestion(Number(item.dataset.index));
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (!suggestions.length) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % suggestions.length;
+        updateActive();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        activeIndex =
+          (activeIndex - 1 + suggestions.length) % suggestions.length;
+        updateActive();
+        break;
+      case "Enter":
+        if (activeIndex >= 0) {
+          e.preventDefault();
+          selectSuggestion(activeIndex);
+        }
+        break;
+      case "Escape":
+        clearSuggestions();
+        break;
     }
   });
 
-  // Enter triggers lookup
-  input.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      document.getElementById("lookupBtn")?.click();
-    }
+  input.addEventListener("blur", () => {
+    // Delay clearing so clicks register
+    setTimeout(() => clearSuggestions(), 100);
   });
 }

--- a/style.css
+++ b/style.css
@@ -175,6 +175,7 @@ h1 {
   display: flex;
   gap: var(--space-3);
   align-items: center;
+  position: relative; /* Allows absolute positioning of suggestion list */
 }
 
 input[type="text"] {
@@ -197,6 +198,44 @@ input[type="text"]:focus {
   outline: none;
   border-color: var(--brand);
   box-shadow: 0 0 0 3px rgba(29, 101, 166, 0.15);
+}
+
+/* Autocomplete suggestion list */
+.autocomplete-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-top: none;
+  max-height: 220px;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: none;
+}
+
+.autocomplete-item {
+  padding: var(--space-2);
+  cursor: pointer;
+}
+
+.autocomplete-item strong {
+  font-weight: 700;
+}
+
+.autocomplete-item.active,
+.autocomplete-item:hover {
+  background: var(--accent-bg);
+}
+
+.autocomplete-list .no-suggestions,
+.autocomplete-list .error {
+  padding: var(--space-2);
+  color: var(--muted);
 }
 
 button {


### PR DESCRIPTION
## Summary
- use `/api/autocomplete` backend endpoint for address suggestions
- add debounced fetch with error handling and bolded matches
- render clickable keyboard navigable suggestion list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac11a263f8832787f457d71358c9c1