### PR TITLE
Route autocomplete through backend API

### DIFF
--- a/src/maps.js
+++ b/src/maps.js
@@ -8,8 +8,9 @@ export function setupAutocomplete() {
   if (!input || !list) return;
 
   // Backend endpoint for autocomplete suggestions. Update here if the
-  // server route changes.
-  const AUTOCOMPLETE_ENDPOINT = "/api/autocomplete";
+  // server route changes. All autocomplete requests should go through
+  // this endpoint and never talk to Google directly.
+  const AUTOCOMPLETE_ENDPOINT = "https://nftapi.cyberwiz.io/api/autocomplete";
 
   let debounceId = null;
   let suggestions = [];
@@ -74,6 +75,7 @@ export function setupAutocomplete() {
         );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
+        if (data.error) throw new Error(data.error);
         const preds = Array.isArray(data.predictions) ? data.predictions : [];
         if (!preds.length) {
           clearSuggestions(


### PR DESCRIPTION
## Summary
- Route address autocomplete queries through `https://nftapi.cyberwiz.io/api/autocomplete`
- Debounce input and show suggestions with matching text highlighted
- Gracefully handle empty results and backend errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac18e107e88327b1979801970bcc8d