### PR TITLE
fix: avoid caching cross-origin API requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,49 @@
-const CACHE_NAME = 'calwep-static-v1';
+const CACHE_NAME = "calwep-static-v1";
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/dist/main.js',
-  '/dist/maps.js',
-  '/dist/pdf.js'
+  "/",
+  "/index.html",
+  "/style.css",
+  "/dist/main.js",
+  "/dist/maps.js",
+  "/dist/pdf.js",
 ];
-self.addEventListener('install', (event) => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
   );
 });
-self.addEventListener('activate', (event) => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+        ),
+      ),
   );
 });
-self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') return;
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  // Only cache same-origin requests. Let API calls to external hosts pass
+  // through untouched so the browser handles them normally. This avoids
+  // accidentally caching responses from the backend API which could cause
+  // stale data or misrouted requests when the base URL changes.
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
   event.respondWith(
-    caches.match(event.request).then((cached) => {
+    caches.match(request).then((cached) => {
       if (cached) return cached;
-      return fetch(event.request).then((response) => {
+      return fetch(request).then((response) => {
         if (response.status === 200) {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
         }
         return response;
       });
-    })
+    }),
   );
 });


### PR DESCRIPTION
## Summary
- ensure service worker ignores cross-origin requests so API calls aren't cached when hostname changes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac297d70108327b100fe6784274a8a