### PR TITLE
fix: avoid caching API requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -33,6 +33,10 @@ self.addEventListener("fetch", (event) => {
   // stale data or misrouted requests when the base URL changes.
   const url = new URL(request.url);
   if (url.origin !== self.location.origin) return;
+  // Bypass caching for API requests so dynamic responses like static map
+  // images are always fetched from the network rather than the service worker
+  // cache.
+  if (url.pathname.startsWith("/api/")) return;
 
   event.respondWith(
     caches.match(request).then((cached) => {


### PR DESCRIPTION
## Summary
- skip service worker caching for `/api/*` requests so dynamic endpoints like `/api/staticmap` are fetched from the network

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac39b32e308327ba011a5c2246c5d1