### PR TITLE
Fix PDF, print, raw data, and share buttons under strict CSP

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -95,6 +95,15 @@ function shareReport() {
 
 window.shareReport = shareReport;
 
+function attachCardActions() {
+  document.getElementById("printBtn")?.addEventListener("click", printReport);
+  document
+    .getElementById("pdfBtn")
+    ?.addEventListener("click", window.downloadPdf);
+  document.getElementById("rawBtn")?.addEventListener("click", downloadRawData);
+  document.getElementById("shareBtn")?.addEventListener("click", shareReport);
+}
+
 // ---------- Config ----------
 // ---------- Utilities ----------
 function isMissing(n) {
@@ -1794,10 +1803,10 @@ function renderResultOld(address, data, elapsedMs) {
         <div class="card__head-left">
           <h2 class="card__title">Results for: ${sanitizeHTML(address)}</h2>
           <div class="card__actions">
-            <button type="button" onclick="printReport()">Print</button>
-            <button type="button" onclick="downloadPdf()">Download PDF</button>
-            <button type="button" onclick="downloadRawData()">Raw Data</button>
-            <button type="button" onclick="shareReport()">Share Link</button>
+            <button type="button" id="printBtn">Print</button>
+            <button type="button" id="pdfBtn">Download PDF</button>
+            <button type="button" id="rawBtn">Raw Data</button>
+            <button type="button" id="shareBtn">Share Link</button>
           </div>
         </div>
         <span class="updated">Updated ${nowStamp()}</span>
@@ -1822,6 +1831,7 @@ function renderResultOld(address, data, elapsedMs) {
       </span>
     </article>
     `);
+  attachCardActions();
 }
 
 // New row-based renderer
@@ -2148,10 +2158,10 @@ function renderResult(address, data, elapsedMs) {
         <div class="card__head-left">
           <h2 class="card__title">Results for: ${sanitizeHTML(address)}</h2>
           <div class="card__actions">
-            <button type="button" onclick="printReport()">Print</button>
-            <button type="button" onclick="downloadPdf()">Download PDF</button>
-            <button type="button" onclick="downloadRawData()">Raw Data</button>
-            <button type="button" onclick="shareReport()">Share Link</button>
+            <button type="button" id="printBtn">Print</button>
+            <button type="button" id="pdfBtn">Download PDF</button>
+            <button type="button" id="rawBtn">Raw Data</button>
+            <button type="button" id="shareBtn">Share Link</button>
           </div>
         </div>
         <span class="updated">Updated ${nowStamp()}</span>
@@ -2173,6 +2183,7 @@ function renderResult(address, data, elapsedMs) {
       </span>
     </article>
     `);
+  attachCardActions();
 }
 // ---------- Flow ----------
 async function lookup() {


### PR DESCRIPTION
## Summary
- Replace inline `onclick` handlers with ID-based buttons and attach JS listeners
- Add helper to wire up print, PDF, raw data, and share actions after rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac3bbe7d588327ad50893b9e134576