### PR TITLE
Add compliance form and modular utilities

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,7 @@
+import { buildApiUrl, fetchJsonWithDiagnostics } from "./api.js";
+
+// Fetch the full dataset for compliance forms.
+export async function fetchFullDatabase() {
+  const url = buildApiUrl("/demographics", { all: 1 });
+  return fetchJsonWithDiagnostics(url);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ import {
 } from "./api.js";
 import { renderLoading, renderError } from "./ui/error.js";
 import { setupAutocomplete } from "./maps.js";
-import { sanitizeHTML, nowStamp, formatDuration } from "./utils.js";
+import { sanitizeHTML, nowStamp, formatDuration, deepMerge } from "./utils.js";
 
 const SENTRY_DSN =
   document.querySelector('meta[name="sentry-dsn"]')?.content || "";
@@ -132,21 +132,6 @@ function fmtPct(n) {
 }
 function titleCase(str = "") {
   return str.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function deepMerge(target = {}, ...sources) {
-  const isObj = (v) => v && typeof v === "object" && !Array.isArray(v);
-  for (const src of sources) {
-    if (!isObj(src)) continue;
-    for (const [key, val] of Object.entries(src)) {
-      if (isObj(val)) {
-        target[key] = deepMerge(isObj(target[key]) ? target[key] : {}, val);
-      } else {
-        target[key] = val;
-      }
-    }
-  }
-  return target;
 }
 
 // Split an array into chunks so API requests stay within URL limits

--- a/src/turf-form.js
+++ b/src/turf-form.js
@@ -1,0 +1,14 @@
+import { fetchFullDatabase } from "./database.js";
+import { renderError } from "./ui/error.js";
+
+async function init() {
+  const out = document.getElementById("databaseDump");
+  try {
+    const data = await fetchFullDatabase();
+    out.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    renderError(err.message, "", 0);
+  }
+}
+
+window.addEventListener("DOMContentLoaded", init);

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,3 +18,18 @@ export function formatDuration(ms = 0) {
   const sLabel = seconds === 1 ? "Second" : "Seconds";
   return `${minutes} ${mLabel} and ${seconds} ${sLabel}`;
 }
+
+export function deepMerge(target = {}, ...sources) {
+  const isObj = (v) => v && typeof v === "object" && !Array.isArray(v);
+  for (const src of sources) {
+    if (!isObj(src)) continue;
+    for (const [key, val] of Object.entries(src)) {
+      if (isObj(val)) {
+        target[key] = deepMerge(isObj(target[key]) ? target[key] : {}, val);
+      } else {
+        target[key] = val;
+      }
+    }
+  }
+  return target;
+}

--- a/turf-form.html
+++ b/turf-form.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commercial Turf Rebate & AB 1572 Compliance</title>
+    <link rel="stylesheet" href="style.css" />
+    <meta name="api-base" content="https://nftapi.cyberwiz.io" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Commercial Turf Rebate & AB 1572 Compliance</h1>
+      <pre id="databaseDump" aria-live="polite"></pre>
+    </main>
+    <script type="module" src="dist/turf-form.js"></script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,9 +4,12 @@ export default defineConfig({
   envPrefix: ["VITE_", "MAPS_"],
   build: {
     rollupOptions: {
-      input: "src/main.js",
+      input: {
+        main: "src/main.js",
+        "turf-form": "src/turf-form.js",
+      },
       output: {
-        entryFileNames: "main.js",
+        entryFileNames: "[name].js",
         chunkFileNames: "[name].js",
         manualChunks: {
           maps: ["src/maps.js"],


### PR DESCRIPTION
## Summary
- export reusable deepMerge util and import in main
- add database loader and turf compliance form page
- extend Vite build to bundle new entry point

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac48047fec8327ba7bc229737a6f24