### PR TITLE
Configure API base via meta tag and drop example page

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,10 @@ const DOMAIN_API_MAP = {
 };
 
 export function resolveApiBaseUrl(hostname = window.location.hostname) {
+  const metaBase = document
+    .querySelector('meta[name="api-base"]')
+    ?.getAttribute("content");
+  if (metaBase) return metaBase;
   for (const [domain, api] of Object.entries(DOMAIN_API_MAP)) {
     if (hostname.includes(domain)) return api;
   }


### PR DESCRIPTION
## Summary
- remove temporary `example.html` and demo `script.js`
- allow overriding API host through `<meta name="api-base">`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e478c488327a017de97879f56bf