### PR TITLE
Improve accessibility and missing-data handling

### DIFF
--- a/dist/error.js
+++ b/dist/error.js
@@ -1,0 +1,1518 @@
+import { A as jt } from "./maps.js";
+/*! @license DOMPurify 3.2.6 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.6/LICENSE */ const {
+  entries: _t,
+  setPrototypeOf: st,
+  isFrozen: Xt,
+  getPrototypeOf: Vt,
+  getOwnPropertyDescriptor: qt,
+} = Object;
+let { freeze: S, seal: O, create: Et } = Object,
+  { apply: xe, construct: Pe } = typeof Reflect < "u" && Reflect;
+S ||
+  (S = function (n) {
+    return n;
+  });
+O ||
+  (O = function (n) {
+    return n;
+  });
+xe ||
+  (xe = function (n, s, r) {
+    return n.apply(s, r);
+  });
+Pe ||
+  (Pe = function (n, s) {
+    return new n(...s);
+  });
+const ce = R(Array.prototype.forEach),
+  Kt = R(Array.prototype.lastIndexOf),
+  lt = R(Array.prototype.pop),
+  q = R(Array.prototype.push),
+  Zt = R(Array.prototype.splice),
+  ue = R(String.prototype.toLowerCase),
+  Ie = R(String.prototype.toString),
+  ct = R(String.prototype.match),
+  K = R(String.prototype.replace),
+  Jt = R(String.prototype.indexOf),
+  Qt = R(String.prototype.trim),
+  b = R(Object.prototype.hasOwnProperty),
+  A = R(RegExp.prototype.test),
+  Z = en(TypeError);
+function R(a) {
+  return function (n) {
+    n instanceof RegExp && (n.lastIndex = 0);
+    for (
+      var s = arguments.length, r = new Array(s > 1 ? s - 1 : 0), f = 1;
+      f < s;
+      f++
+    )
+      r[f - 1] = arguments[f];
+    return xe(a, n, r);
+  };
+}
+function en(a) {
+  return function () {
+    for (var n = arguments.length, s = new Array(n), r = 0; r < n; r++)
+      s[r] = arguments[r];
+    return Pe(a, s);
+  };
+}
+function l(a, n) {
+  let s = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : ue;
+  st && st(a, null);
+  let r = n.length;
+  for (; r--; ) {
+    let f = n[r];
+    if (typeof f == "string") {
+      const y = s(f);
+      y !== f && (Xt(n) || (n[r] = y), (f = y));
+    }
+    a[f] = !0;
+  }
+  return a;
+}
+function tn(a) {
+  for (let n = 0; n < a.length; n++) b(a, n) || (a[n] = null);
+  return a;
+}
+function C(a) {
+  const n = Et(null);
+  for (const [s, r] of _t(a))
+    b(a, s) &&
+      (Array.isArray(r)
+        ? (n[s] = tn(r))
+        : r && typeof r == "object" && r.constructor === Object
+          ? (n[s] = C(r))
+          : (n[s] = r));
+  return n;
+}
+function J(a, n) {
+  for (; a !== null; ) {
+    const r = qt(a, n);
+    if (r) {
+      if (r.get) return R(r.get);
+      if (typeof r.value == "function") return R(r.value);
+    }
+    a = Vt(a);
+  }
+  function s() {
+    return null;
+  }
+  return s;
+}
+const ft = S([
+    "a",
+    "abbr",
+    "acronym",
+    "address",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "bdi",
+    "bdo",
+    "big",
+    "blink",
+    "blockquote",
+    "body",
+    "br",
+    "button",
+    "canvas",
+    "caption",
+    "center",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "content",
+    "data",
+    "datalist",
+    "dd",
+    "decorator",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "element",
+    "em",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "font",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "hr",
+    "html",
+    "i",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "label",
+    "legend",
+    "li",
+    "main",
+    "map",
+    "mark",
+    "marquee",
+    "menu",
+    "menuitem",
+    "meter",
+    "nav",
+    "nobr",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "ruby",
+    "s",
+    "samp",
+    "section",
+    "select",
+    "shadow",
+    "small",
+    "source",
+    "spacer",
+    "span",
+    "strike",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "template",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "tr",
+    "track",
+    "tt",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
+  ]),
+  Me = S([
+    "svg",
+    "a",
+    "altglyph",
+    "altglyphdef",
+    "altglyphitem",
+    "animatecolor",
+    "animatemotion",
+    "animatetransform",
+    "circle",
+    "clippath",
+    "defs",
+    "desc",
+    "ellipse",
+    "filter",
+    "font",
+    "g",
+    "glyph",
+    "glyphref",
+    "hkern",
+    "image",
+    "line",
+    "lineargradient",
+    "marker",
+    "mask",
+    "metadata",
+    "mpath",
+    "path",
+    "pattern",
+    "polygon",
+    "polyline",
+    "radialgradient",
+    "rect",
+    "stop",
+    "style",
+    "switch",
+    "symbol",
+    "text",
+    "textpath",
+    "title",
+    "tref",
+    "tspan",
+    "view",
+    "vkern",
+  ]),
+  Ne = S([
+    "feBlend",
+    "feColorMatrix",
+    "feComponentTransfer",
+    "feComposite",
+    "feConvolveMatrix",
+    "feDiffuseLighting",
+    "feDisplacementMap",
+    "feDistantLight",
+    "feDropShadow",
+    "feFlood",
+    "feFuncA",
+    "feFuncB",
+    "feFuncG",
+    "feFuncR",
+    "feGaussianBlur",
+    "feImage",
+    "feMerge",
+    "feMergeNode",
+    "feMorphology",
+    "feOffset",
+    "fePointLight",
+    "feSpecularLighting",
+    "feSpotLight",
+    "feTile",
+    "feTurbulence",
+  ]),
+  nn = S([
+    "animate",
+    "color-profile",
+    "cursor",
+    "discard",
+    "font-face",
+    "font-face-format",
+    "font-face-name",
+    "font-face-src",
+    "font-face-uri",
+    "foreignobject",
+    "hatch",
+    "hatchpath",
+    "mesh",
+    "meshgradient",
+    "meshpatch",
+    "meshrow",
+    "missing-glyph",
+    "script",
+    "set",
+    "solidcolor",
+    "unknown",
+    "use",
+  ]),
+  Ce = S([
+    "math",
+    "menclose",
+    "merror",
+    "mfenced",
+    "mfrac",
+    "mglyph",
+    "mi",
+    "mlabeledtr",
+    "mmultiscripts",
+    "mn",
+    "mo",
+    "mover",
+    "mpadded",
+    "mphantom",
+    "mroot",
+    "mrow",
+    "ms",
+    "mspace",
+    "msqrt",
+    "mstyle",
+    "msub",
+    "msup",
+    "msubsup",
+    "mtable",
+    "mtd",
+    "mtext",
+    "mtr",
+    "munder",
+    "munderover",
+    "mprescripts",
+  ]),
+  on = S([
+    "maction",
+    "maligngroup",
+    "malignmark",
+    "mlongdiv",
+    "mscarries",
+    "mscarry",
+    "msgroup",
+    "mstack",
+    "msline",
+    "msrow",
+    "semantics",
+    "annotation",
+    "annotation-xml",
+    "mprescripts",
+    "none",
+  ]),
+  ut = S(["#text"]),
+  pt = S([
+    "accept",
+    "action",
+    "align",
+    "alt",
+    "autocapitalize",
+    "autocomplete",
+    "autopictureinpicture",
+    "autoplay",
+    "background",
+    "bgcolor",
+    "border",
+    "capture",
+    "cellpadding",
+    "cellspacing",
+    "checked",
+    "cite",
+    "class",
+    "clear",
+    "color",
+    "cols",
+    "colspan",
+    "controls",
+    "controlslist",
+    "coords",
+    "crossorigin",
+    "datetime",
+    "decoding",
+    "default",
+    "dir",
+    "disabled",
+    "disablepictureinpicture",
+    "disableremoteplayback",
+    "download",
+    "draggable",
+    "enctype",
+    "enterkeyhint",
+    "face",
+    "for",
+    "headers",
+    "height",
+    "hidden",
+    "high",
+    "href",
+    "hreflang",
+    "id",
+    "inputmode",
+    "integrity",
+    "ismap",
+    "kind",
+    "label",
+    "lang",
+    "list",
+    "loading",
+    "loop",
+    "low",
+    "max",
+    "maxlength",
+    "media",
+    "method",
+    "min",
+    "minlength",
+    "multiple",
+    "muted",
+    "name",
+    "nonce",
+    "noshade",
+    "novalidate",
+    "nowrap",
+    "open",
+    "optimum",
+    "pattern",
+    "placeholder",
+    "playsinline",
+    "popover",
+    "popovertarget",
+    "popovertargetaction",
+    "poster",
+    "preload",
+    "pubdate",
+    "radiogroup",
+    "readonly",
+    "rel",
+    "required",
+    "rev",
+    "reversed",
+    "role",
+    "rows",
+    "rowspan",
+    "spellcheck",
+    "scope",
+    "selected",
+    "shape",
+    "size",
+    "sizes",
+    "span",
+    "srclang",
+    "start",
+    "src",
+    "srcset",
+    "step",
+    "style",
+    "summary",
+    "tabindex",
+    "title",
+    "translate",
+    "type",
+    "usemap",
+    "valign",
+    "value",
+    "width",
+    "wrap",
+    "xmlns",
+    "slot",
+  ]),
+  we = S([
+    "accent-height",
+    "accumulate",
+    "additive",
+    "alignment-baseline",
+    "amplitude",
+    "ascent",
+    "attributename",
+    "attributetype",
+    "azimuth",
+    "basefrequency",
+    "baseline-shift",
+    "begin",
+    "bias",
+    "by",
+    "class",
+    "clip",
+    "clippathunits",
+    "clip-path",
+    "clip-rule",
+    "color",
+    "color-interpolation",
+    "color-interpolation-filters",
+    "color-profile",
+    "color-rendering",
+    "cx",
+    "cy",
+    "d",
+    "dx",
+    "dy",
+    "diffuseconstant",
+    "direction",
+    "display",
+    "divisor",
+    "dur",
+    "edgemode",
+    "elevation",
+    "end",
+    "exponent",
+    "fill",
+    "fill-opacity",
+    "fill-rule",
+    "filter",
+    "filterunits",
+    "flood-color",
+    "flood-opacity",
+    "font-family",
+    "font-size",
+    "font-size-adjust",
+    "font-stretch",
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "fx",
+    "fy",
+    "g1",
+    "g2",
+    "glyph-name",
+    "glyphref",
+    "gradientunits",
+    "gradienttransform",
+    "height",
+    "href",
+    "id",
+    "image-rendering",
+    "in",
+    "in2",
+    "intercept",
+    "k",
+    "k1",
+    "k2",
+    "k3",
+    "k4",
+    "kerning",
+    "keypoints",
+    "keysplines",
+    "keytimes",
+    "lang",
+    "lengthadjust",
+    "letter-spacing",
+    "kernelmatrix",
+    "kernelunitlength",
+    "lighting-color",
+    "local",
+    "marker-end",
+    "marker-mid",
+    "marker-start",
+    "markerheight",
+    "markerunits",
+    "markerwidth",
+    "maskcontentunits",
+    "maskunits",
+    "max",
+    "mask",
+    "media",
+    "method",
+    "mode",
+    "min",
+    "name",
+    "numoctaves",
+    "offset",
+    "operator",
+    "opacity",
+    "order",
+    "orient",
+    "orientation",
+    "origin",
+    "overflow",
+    "paint-order",
+    "path",
+    "pathlength",
+    "patterncontentunits",
+    "patterntransform",
+    "patternunits",
+    "points",
+    "preservealpha",
+    "preserveaspectratio",
+    "primitiveunits",
+    "r",
+    "rx",
+    "ry",
+    "radius",
+    "refx",
+    "refy",
+    "repeatcount",
+    "repeatdur",
+    "restart",
+    "result",
+    "rotate",
+    "scale",
+    "seed",
+    "shape-rendering",
+    "slope",
+    "specularconstant",
+    "specularexponent",
+    "spreadmethod",
+    "startoffset",
+    "stddeviation",
+    "stitchtiles",
+    "stop-color",
+    "stop-opacity",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-miterlimit",
+    "stroke-opacity",
+    "stroke",
+    "stroke-width",
+    "style",
+    "surfacescale",
+    "systemlanguage",
+    "tabindex",
+    "tablevalues",
+    "targetx",
+    "targety",
+    "transform",
+    "transform-origin",
+    "text-anchor",
+    "text-decoration",
+    "text-rendering",
+    "textlength",
+    "type",
+    "u1",
+    "u2",
+    "unicode",
+    "values",
+    "viewbox",
+    "visibility",
+    "version",
+    "vert-adv-y",
+    "vert-origin-x",
+    "vert-origin-y",
+    "width",
+    "word-spacing",
+    "wrap",
+    "writing-mode",
+    "xchannelselector",
+    "ychannelselector",
+    "x",
+    "x1",
+    "x2",
+    "xmlns",
+    "y",
+    "y1",
+    "y2",
+    "z",
+    "zoomandpan",
+  ]),
+  mt = S([
+    "accent",
+    "accentunder",
+    "align",
+    "bevelled",
+    "close",
+    "columnsalign",
+    "columnlines",
+    "columnspan",
+    "denomalign",
+    "depth",
+    "dir",
+    "display",
+    "displaystyle",
+    "encoding",
+    "fence",
+    "frame",
+    "height",
+    "href",
+    "id",
+    "largeop",
+    "length",
+    "linethickness",
+    "lspace",
+    "lquote",
+    "mathbackground",
+    "mathcolor",
+    "mathsize",
+    "mathvariant",
+    "maxsize",
+    "minsize",
+    "movablelimits",
+    "notation",
+    "numalign",
+    "open",
+    "rowalign",
+    "rowlines",
+    "rowspacing",
+    "rowspan",
+    "rspace",
+    "rquote",
+    "scriptlevel",
+    "scriptminsize",
+    "scriptsizemultiplier",
+    "selection",
+    "separator",
+    "separators",
+    "stretchy",
+    "subscriptshift",
+    "supscriptshift",
+    "symmetric",
+    "voffset",
+    "width",
+    "xmlns",
+  ]),
+  fe = S(["xlink:href", "xml:id", "xlink:title", "xml:space", "xmlns:xlink"]),
+  an = O(/\{\{[\w\W]*|[\w\W]*\}\}/gm),
+  rn = O(/<%[\w\W]*|[\w\W]*%>/gm),
+  sn = O(/\$\{[\w\W]*/gm),
+  ln = O(/^data-[\-\w.\u00B7-\uFFFF]+$/),
+  cn = O(/^aria-[\-\w]+$/),
+  gt = O(
+    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+  ),
+  fn = O(/^(?:\w+script|data):/i),
+  un = O(/[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g),
+  ht = O(/^html$/i),
+  pn = O(/^[a-z][.\w]*(-[.\w]+)+$/i);
+var dt = Object.freeze({
+  __proto__: null,
+  ARIA_ATTR: cn,
+  ATTR_WHITESPACE: un,
+  CUSTOM_ELEMENT: pn,
+  DATA_ATTR: ln,
+  DOCTYPE_NAME: ht,
+  ERB_EXPR: rn,
+  IS_ALLOWED_URI: gt,
+  IS_SCRIPT_OR_DATA: fn,
+  MUSTACHE_EXPR: an,
+  TMPLIT_EXPR: sn,
+});
+const Q = {
+    element: 1,
+    text: 3,
+    progressingInstruction: 7,
+    comment: 8,
+    document: 9,
+  },
+  mn = function () {
+    return typeof window > "u" ? null : window;
+  },
+  dn = function (n, s) {
+    if (typeof n != "object" || typeof n.createPolicy != "function")
+      return null;
+    let r = null;
+    const f = "data-tt-policy-suffix";
+    s && s.hasAttribute(f) && (r = s.getAttribute(f));
+    const y = "dompurify" + (r ? "#" + r : "");
+    try {
+      return n.createPolicy(y, {
+        createHTML(x) {
+          return x;
+        },
+        createScriptURL(x) {
+          return x;
+        },
+      });
+    } catch {
+      return (
+        console.warn("TrustedTypes policy " + y + " could not be created."),
+        null
+      );
+    }
+  },
+  Tt = function () {
+    return {
+      afterSanitizeAttributes: [],
+      afterSanitizeElements: [],
+      afterSanitizeShadowDOM: [],
+      beforeSanitizeAttributes: [],
+      beforeSanitizeElements: [],
+      beforeSanitizeShadowDOM: [],
+      uponSanitizeAttribute: [],
+      uponSanitizeElement: [],
+      uponSanitizeShadowNode: [],
+    };
+  };
+function At() {
+  let a = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : mn();
+  const n = (i) => At(i);
+  if (
+    ((n.version = "3.2.6"),
+    (n.removed = []),
+    !a || !a.document || a.document.nodeType !== Q.document || !a.Element)
+  )
+    return ((n.isSupported = !1), n);
+  let { document: s } = a;
+  const r = s,
+    f = r.currentScript,
+    {
+      DocumentFragment: y,
+      HTMLTemplateElement: x,
+      Node: pe,
+      Element: ve,
+      NodeFilter: W,
+      NamedNodeMap: yt = a.NamedNodeMap || a.MozNamedAttrMap,
+      HTMLFormElement: Lt,
+      DOMParser: Ot,
+      trustedTypes: ee,
+    } = a,
+    B = ve.prototype,
+    bt = J(B, "cloneNode"),
+    Dt = J(B, "remove"),
+    It = J(B, "nextSibling"),
+    Mt = J(B, "childNodes"),
+    te = J(B, "parentNode");
+  if (typeof x == "function") {
+    const i = s.createElement("template");
+    i.content && i.content.ownerDocument && (s = i.content.ownerDocument);
+  }
+  let g,
+    Y = "";
+  const {
+      implementation: me,
+      createNodeIterator: Nt,
+      createDocumentFragment: Ct,
+      getElementsByTagName: wt,
+    } = s,
+    { importNode: xt } = r;
+  let h = Tt();
+  n.isSupported =
+    typeof _t == "function" &&
+    typeof te == "function" &&
+    me &&
+    me.createHTMLDocument !== void 0;
+  const {
+    MUSTACHE_EXPR: de,
+    ERB_EXPR: Te,
+    TMPLIT_EXPR: _e,
+    DATA_ATTR: Pt,
+    ARIA_ATTR: vt,
+    IS_SCRIPT_OR_DATA: kt,
+    ATTR_WHITESPACE: ke,
+    CUSTOM_ELEMENT: Ut,
+  } = dt;
+  let { IS_ALLOWED_URI: Ue } = dt,
+    m = null;
+  const Fe = l({}, [...ft, ...Me, ...Ne, ...Ce, ...ut]);
+  let T = null;
+  const He = l({}, [...pt, ...we, ...mt, ...fe]);
+  let u = Object.seal(
+      Et(null, {
+        tagNameCheck: {
+          writable: !0,
+          configurable: !1,
+          enumerable: !0,
+          value: null,
+        },
+        attributeNameCheck: {
+          writable: !0,
+          configurable: !1,
+          enumerable: !0,
+          value: null,
+        },
+        allowCustomizedBuiltInElements: {
+          writable: !0,
+          configurable: !1,
+          enumerable: !0,
+          value: !1,
+        },
+      }),
+    ),
+    $ = null,
+    Ee = null,
+    ze = !0,
+    ge = !0,
+    Ge = !1,
+    We = !0,
+    P = !1,
+    ne = !0,
+    w = !1,
+    he = !1,
+    Ae = !1,
+    v = !1,
+    oe = !1,
+    ie = !1,
+    Be = !0,
+    Ye = !1;
+  const Ft = "user-content-";
+  let Se = !0,
+    j = !1,
+    k = {},
+    U = null;
+  const $e = l({}, [
+    "annotation-xml",
+    "audio",
+    "colgroup",
+    "desc",
+    "foreignobject",
+    "head",
+    "iframe",
+    "math",
+    "mi",
+    "mn",
+    "mo",
+    "ms",
+    "mtext",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+    "script",
+    "style",
+    "svg",
+    "template",
+    "thead",
+    "title",
+    "video",
+    "xmp",
+  ]);
+  let je = null;
+  const Xe = l({}, ["audio", "video", "img", "source", "image", "track"]);
+  let Re = null;
+  const Ve = l({}, [
+      "alt",
+      "class",
+      "for",
+      "id",
+      "label",
+      "name",
+      "pattern",
+      "placeholder",
+      "role",
+      "summary",
+      "title",
+      "value",
+      "style",
+      "xmlns",
+    ]),
+    ae = "http://www.w3.org/1998/Math/MathML",
+    re = "http://www.w3.org/2000/svg",
+    I = "http://www.w3.org/1999/xhtml";
+  let F = I,
+    ye = !1,
+    Le = null;
+  const Ht = l({}, [ae, re, I], Ie);
+  let se = l({}, ["mi", "mo", "mn", "ms", "mtext"]),
+    le = l({}, ["annotation-xml"]);
+  const zt = l({}, ["title", "style", "font", "a", "script"]);
+  let X = null;
+  const Gt = ["application/xhtml+xml", "text/html"],
+    Wt = "text/html";
+  let d = null,
+    H = null;
+  const Bt = s.createElement("form"),
+    qe = function (e) {
+      return e instanceof RegExp || e instanceof Function;
+    },
+    Oe = function () {
+      let e =
+        arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+      if (!(H && H === e)) {
+        if (
+          ((!e || typeof e != "object") && (e = {}),
+          (e = C(e)),
+          (X =
+            Gt.indexOf(e.PARSER_MEDIA_TYPE) === -1 ? Wt : e.PARSER_MEDIA_TYPE),
+          (d = X === "application/xhtml+xml" ? Ie : ue),
+          (m = b(e, "ALLOWED_TAGS") ? l({}, e.ALLOWED_TAGS, d) : Fe),
+          (T = b(e, "ALLOWED_ATTR") ? l({}, e.ALLOWED_ATTR, d) : He),
+          (Le = b(e, "ALLOWED_NAMESPACES")
+            ? l({}, e.ALLOWED_NAMESPACES, Ie)
+            : Ht),
+          (Re = b(e, "ADD_URI_SAFE_ATTR")
+            ? l(C(Ve), e.ADD_URI_SAFE_ATTR, d)
+            : Ve),
+          (je = b(e, "ADD_DATA_URI_TAGS")
+            ? l(C(Xe), e.ADD_DATA_URI_TAGS, d)
+            : Xe),
+          (U = b(e, "FORBID_CONTENTS") ? l({}, e.FORBID_CONTENTS, d) : $e),
+          ($ = b(e, "FORBID_TAGS") ? l({}, e.FORBID_TAGS, d) : C({})),
+          (Ee = b(e, "FORBID_ATTR") ? l({}, e.FORBID_ATTR, d) : C({})),
+          (k = b(e, "USE_PROFILES") ? e.USE_PROFILES : !1),
+          (ze = e.ALLOW_ARIA_ATTR !== !1),
+          (ge = e.ALLOW_DATA_ATTR !== !1),
+          (Ge = e.ALLOW_UNKNOWN_PROTOCOLS || !1),
+          (We = e.ALLOW_SELF_CLOSE_IN_ATTR !== !1),
+          (P = e.SAFE_FOR_TEMPLATES || !1),
+          (ne = e.SAFE_FOR_XML !== !1),
+          (w = e.WHOLE_DOCUMENT || !1),
+          (v = e.RETURN_DOM || !1),
+          (oe = e.RETURN_DOM_FRAGMENT || !1),
+          (ie = e.RETURN_TRUSTED_TYPE || !1),
+          (Ae = e.FORCE_BODY || !1),
+          (Be = e.SANITIZE_DOM !== !1),
+          (Ye = e.SANITIZE_NAMED_PROPS || !1),
+          (Se = e.KEEP_CONTENT !== !1),
+          (j = e.IN_PLACE || !1),
+          (Ue = e.ALLOWED_URI_REGEXP || gt),
+          (F = e.NAMESPACE || I),
+          (se = e.MATHML_TEXT_INTEGRATION_POINTS || se),
+          (le = e.HTML_INTEGRATION_POINTS || le),
+          (u = e.CUSTOM_ELEMENT_HANDLING || {}),
+          e.CUSTOM_ELEMENT_HANDLING &&
+            qe(e.CUSTOM_ELEMENT_HANDLING.tagNameCheck) &&
+            (u.tagNameCheck = e.CUSTOM_ELEMENT_HANDLING.tagNameCheck),
+          e.CUSTOM_ELEMENT_HANDLING &&
+            qe(e.CUSTOM_ELEMENT_HANDLING.attributeNameCheck) &&
+            (u.attributeNameCheck =
+              e.CUSTOM_ELEMENT_HANDLING.attributeNameCheck),
+          e.CUSTOM_ELEMENT_HANDLING &&
+            typeof e.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements ==
+              "boolean" &&
+            (u.allowCustomizedBuiltInElements =
+              e.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements),
+          P && (ge = !1),
+          oe && (v = !0),
+          k &&
+            ((m = l({}, ut)),
+            (T = []),
+            k.html === !0 && (l(m, ft), l(T, pt)),
+            k.svg === !0 && (l(m, Me), l(T, we), l(T, fe)),
+            k.svgFilters === !0 && (l(m, Ne), l(T, we), l(T, fe)),
+            k.mathMl === !0 && (l(m, Ce), l(T, mt), l(T, fe))),
+          e.ADD_TAGS && (m === Fe && (m = C(m)), l(m, e.ADD_TAGS, d)),
+          e.ADD_ATTR && (T === He && (T = C(T)), l(T, e.ADD_ATTR, d)),
+          e.ADD_URI_SAFE_ATTR && l(Re, e.ADD_URI_SAFE_ATTR, d),
+          e.FORBID_CONTENTS &&
+            (U === $e && (U = C(U)), l(U, e.FORBID_CONTENTS, d)),
+          Se && (m["#text"] = !0),
+          w && l(m, ["html", "head", "body"]),
+          m.table && (l(m, ["tbody"]), delete $.tbody),
+          e.TRUSTED_TYPES_POLICY)
+        ) {
+          if (typeof e.TRUSTED_TYPES_POLICY.createHTML != "function")
+            throw Z(
+              'TRUSTED_TYPES_POLICY configuration option must provide a "createHTML" hook.',
+            );
+          if (typeof e.TRUSTED_TYPES_POLICY.createScriptURL != "function")
+            throw Z(
+              'TRUSTED_TYPES_POLICY configuration option must provide a "createScriptURL" hook.',
+            );
+          ((g = e.TRUSTED_TYPES_POLICY), (Y = g.createHTML("")));
+        } else
+          (g === void 0 && (g = dn(ee, f)),
+            g !== null && typeof Y == "string" && (Y = g.createHTML("")));
+        (S && S(e), (H = e));
+      }
+    },
+    Ke = l({}, [...Me, ...Ne, ...nn]),
+    Ze = l({}, [...Ce, ...on]),
+    Yt = function (e) {
+      let t = te(e);
+      (!t || !t.tagName) && (t = { namespaceURI: F, tagName: "template" });
+      const o = ue(e.tagName),
+        c = ue(t.tagName);
+      return Le[e.namespaceURI]
+        ? e.namespaceURI === re
+          ? t.namespaceURI === I
+            ? o === "svg"
+            : t.namespaceURI === ae
+              ? o === "svg" && (c === "annotation-xml" || se[c])
+              : !!Ke[o]
+          : e.namespaceURI === ae
+            ? t.namespaceURI === I
+              ? o === "math"
+              : t.namespaceURI === re
+                ? o === "math" && le[c]
+                : !!Ze[o]
+            : e.namespaceURI === I
+              ? (t.namespaceURI === re && !le[c]) ||
+                (t.namespaceURI === ae && !se[c])
+                ? !1
+                : !Ze[o] && (zt[o] || !Ke[o])
+              : !!(X === "application/xhtml+xml" && Le[e.namespaceURI])
+        : !1;
+    },
+    D = function (e) {
+      q(n.removed, { element: e });
+      try {
+        te(e).removeChild(e);
+      } catch {
+        Dt(e);
+      }
+    },
+    z = function (e, t) {
+      try {
+        q(n.removed, { attribute: t.getAttributeNode(e), from: t });
+      } catch {
+        q(n.removed, { attribute: null, from: t });
+      }
+      if ((t.removeAttribute(e), e === "is"))
+        if (v || oe)
+          try {
+            D(t);
+          } catch {}
+        else
+          try {
+            t.setAttribute(e, "");
+          } catch {}
+    },
+    Je = function (e) {
+      let t = null,
+        o = null;
+      if (Ae) e = "<remove></remove>" + e;
+      else {
+        const p = ct(e, /^[\r\n\t ]+/);
+        o = p && p[0];
+      }
+      X === "application/xhtml+xml" &&
+        F === I &&
+        (e =
+          '<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>' +
+          e +
+          "</body></html>");
+      const c = g ? g.createHTML(e) : e;
+      if (F === I)
+        try {
+          t = new Ot().parseFromString(c, X);
+        } catch {}
+      if (!t || !t.documentElement) {
+        t = me.createDocument(F, "template", null);
+        try {
+          t.documentElement.innerHTML = ye ? Y : c;
+        } catch {}
+      }
+      const _ = t.body || t.documentElement;
+      return (
+        e && o && _.insertBefore(s.createTextNode(o), _.childNodes[0] || null),
+        F === I ? wt.call(t, w ? "html" : "body")[0] : w ? t.documentElement : _
+      );
+    },
+    Qe = function (e) {
+      return Nt.call(
+        e.ownerDocument || e,
+        e,
+        W.SHOW_ELEMENT |
+          W.SHOW_COMMENT |
+          W.SHOW_TEXT |
+          W.SHOW_PROCESSING_INSTRUCTION |
+          W.SHOW_CDATA_SECTION,
+        null,
+      );
+    },
+    be = function (e) {
+      return (
+        e instanceof Lt &&
+        (typeof e.nodeName != "string" ||
+          typeof e.textContent != "string" ||
+          typeof e.removeChild != "function" ||
+          !(e.attributes instanceof yt) ||
+          typeof e.removeAttribute != "function" ||
+          typeof e.setAttribute != "function" ||
+          typeof e.namespaceURI != "string" ||
+          typeof e.insertBefore != "function" ||
+          typeof e.hasChildNodes != "function")
+      );
+    },
+    et = function (e) {
+      return typeof pe == "function" && e instanceof pe;
+    };
+  function M(i, e, t) {
+    ce(i, (o) => {
+      o.call(n, e, t, H);
+    });
+  }
+  const tt = function (e) {
+      let t = null;
+      if ((M(h.beforeSanitizeElements, e, null), be(e))) return (D(e), !0);
+      const o = d(e.nodeName);
+      if (
+        (M(h.uponSanitizeElement, e, { tagName: o, allowedTags: m }),
+        (ne &&
+          e.hasChildNodes() &&
+          !et(e.firstElementChild) &&
+          A(/<[/\w!]/g, e.innerHTML) &&
+          A(/<[/\w!]/g, e.textContent)) ||
+          e.nodeType === Q.progressingInstruction ||
+          (ne && e.nodeType === Q.comment && A(/<[/\w]/g, e.data)))
+      )
+        return (D(e), !0);
+      if (!m[o] || $[o]) {
+        if (
+          !$[o] &&
+          ot(o) &&
+          ((u.tagNameCheck instanceof RegExp && A(u.tagNameCheck, o)) ||
+            (u.tagNameCheck instanceof Function && u.tagNameCheck(o)))
+        )
+          return !1;
+        if (Se && !U[o]) {
+          const c = te(e) || e.parentNode,
+            _ = Mt(e) || e.childNodes;
+          if (_ && c) {
+            const p = _.length;
+            for (let L = p - 1; L >= 0; --L) {
+              const N = bt(_[L], !0);
+              ((N.__removalCount = (e.__removalCount || 0) + 1),
+                c.insertBefore(N, It(e)));
+            }
+          }
+        }
+        return (D(e), !0);
+      }
+      return (e instanceof ve && !Yt(e)) ||
+        ((o === "noscript" || o === "noembed" || o === "noframes") &&
+          A(/<\/no(script|embed|frames)/i, e.innerHTML))
+        ? (D(e), !0)
+        : (P &&
+            e.nodeType === Q.text &&
+            ((t = e.textContent),
+            ce([de, Te, _e], (c) => {
+              t = K(t, c, " ");
+            }),
+            e.textContent !== t &&
+              (q(n.removed, { element: e.cloneNode() }), (e.textContent = t))),
+          M(h.afterSanitizeElements, e, null),
+          !1);
+    },
+    nt = function (e, t, o) {
+      if (Be && (t === "id" || t === "name") && (o in s || o in Bt)) return !1;
+      if (!(ge && !Ee[t] && A(Pt, t))) {
+        if (!(ze && A(vt, t))) {
+          if (!T[t] || Ee[t]) {
+            if (
+              !(
+                (ot(e) &&
+                  ((u.tagNameCheck instanceof RegExp && A(u.tagNameCheck, e)) ||
+                    (u.tagNameCheck instanceof Function &&
+                      u.tagNameCheck(e))) &&
+                  ((u.attributeNameCheck instanceof RegExp &&
+                    A(u.attributeNameCheck, t)) ||
+                    (u.attributeNameCheck instanceof Function &&
+                      u.attributeNameCheck(t)))) ||
+                (t === "is" &&
+                  u.allowCustomizedBuiltInElements &&
+                  ((u.tagNameCheck instanceof RegExp && A(u.tagNameCheck, o)) ||
+                    (u.tagNameCheck instanceof Function && u.tagNameCheck(o))))
+              )
+            )
+              return !1;
+          } else if (!Re[t]) {
+            if (!A(Ue, K(o, ke, ""))) {
+              if (
+                !(
+                  (t === "src" || t === "xlink:href" || t === "href") &&
+                  e !== "script" &&
+                  Jt(o, "data:") === 0 &&
+                  je[e]
+                )
+              ) {
+                if (!(Ge && !A(kt, K(o, ke, "")))) {
+                  if (o) return !1;
+                }
+              }
+            }
+          }
+        }
+      }
+      return !0;
+    },
+    ot = function (e) {
+      return e !== "annotation-xml" && ct(e, Ut);
+    },
+    it = function (e) {
+      M(h.beforeSanitizeAttributes, e, null);
+      const { attributes: t } = e;
+      if (!t || be(e)) return;
+      const o = {
+        attrName: "",
+        attrValue: "",
+        keepAttr: !0,
+        allowedAttributes: T,
+        forceKeepAttr: void 0,
+      };
+      let c = t.length;
+      for (; c--; ) {
+        const _ = t[c],
+          { name: p, namespaceURI: L, value: N } = _,
+          V = d(p),
+          De = N;
+        let E = p === "value" ? De : Qt(De);
+        if (
+          ((o.attrName = V),
+          (o.attrValue = E),
+          (o.keepAttr = !0),
+          (o.forceKeepAttr = void 0),
+          M(h.uponSanitizeAttribute, e, o),
+          (E = o.attrValue),
+          Ye && (V === "id" || V === "name") && (z(p, e), (E = Ft + E)),
+          ne && A(/((--!?|])>)|<\/(style|title)/i, E))
+        ) {
+          z(p, e);
+          continue;
+        }
+        if (o.forceKeepAttr) continue;
+        if (!o.keepAttr) {
+          z(p, e);
+          continue;
+        }
+        if (!We && A(/\/>/i, E)) {
+          z(p, e);
+          continue;
+        }
+        P &&
+          ce([de, Te, _e], (rt) => {
+            E = K(E, rt, " ");
+          });
+        const at = d(e.nodeName);
+        if (!nt(at, V, E)) {
+          z(p, e);
+          continue;
+        }
+        if (
+          g &&
+          typeof ee == "object" &&
+          typeof ee.getAttributeType == "function" &&
+          !L
+        )
+          switch (ee.getAttributeType(at, V)) {
+            case "TrustedHTML": {
+              E = g.createHTML(E);
+              break;
+            }
+            case "TrustedScriptURL": {
+              E = g.createScriptURL(E);
+              break;
+            }
+          }
+        if (E !== De)
+          try {
+            (L ? e.setAttributeNS(L, p, E) : e.setAttribute(p, E),
+              be(e) ? D(e) : lt(n.removed));
+          } catch {
+            z(p, e);
+          }
+      }
+      M(h.afterSanitizeAttributes, e, null);
+    },
+    $t = function i(e) {
+      let t = null;
+      const o = Qe(e);
+      for (M(h.beforeSanitizeShadowDOM, e, null); (t = o.nextNode()); )
+        (M(h.uponSanitizeShadowNode, t, null),
+          tt(t),
+          it(t),
+          t.content instanceof y && i(t.content));
+      M(h.afterSanitizeShadowDOM, e, null);
+    };
+  return (
+    (n.sanitize = function (i) {
+      let e =
+          arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {},
+        t = null,
+        o = null,
+        c = null,
+        _ = null;
+      if (((ye = !i), ye && (i = "<!-->"), typeof i != "string" && !et(i)))
+        if (typeof i.toString == "function") {
+          if (((i = i.toString()), typeof i != "string"))
+            throw Z("dirty is not a string, aborting");
+        } else throw Z("toString is not a function");
+      if (!n.isSupported) return i;
+      if (
+        (he || Oe(e), (n.removed = []), typeof i == "string" && (j = !1), j)
+      ) {
+        if (i.nodeName) {
+          const N = d(i.nodeName);
+          if (!m[N] || $[N])
+            throw Z("root node is forbidden and cannot be sanitized in-place");
+        }
+      } else if (i instanceof pe)
+        ((t = Je("<!---->")),
+          (o = t.ownerDocument.importNode(i, !0)),
+          (o.nodeType === Q.element && o.nodeName === "BODY") ||
+          o.nodeName === "HTML"
+            ? (t = o)
+            : t.appendChild(o));
+      else {
+        if (!v && !P && !w && i.indexOf("<") === -1)
+          return g && ie ? g.createHTML(i) : i;
+        if (((t = Je(i)), !t)) return v ? null : ie ? Y : "";
+      }
+      t && Ae && D(t.firstChild);
+      const p = Qe(j ? i : t);
+      for (; (c = p.nextNode()); )
+        (tt(c), it(c), c.content instanceof y && $t(c.content));
+      if (j) return i;
+      if (v) {
+        if (oe)
+          for (_ = Ct.call(t.ownerDocument); t.firstChild; )
+            _.appendChild(t.firstChild);
+        else _ = t;
+        return (
+          (T.shadowroot || T.shadowrootmode) && (_ = xt.call(r, _, !0)),
+          _
+        );
+      }
+      let L = w ? t.outerHTML : t.innerHTML;
+      return (
+        w &&
+          m["!doctype"] &&
+          t.ownerDocument &&
+          t.ownerDocument.doctype &&
+          t.ownerDocument.doctype.name &&
+          A(ht, t.ownerDocument.doctype.name) &&
+          (L =
+            "<!DOCTYPE " +
+            t.ownerDocument.doctype.name +
+            `>
+` +
+            L),
+        P &&
+          ce([de, Te, _e], (N) => {
+            L = K(L, N, " ");
+          }),
+        g && ie ? g.createHTML(L) : L
+      );
+    }),
+    (n.setConfig = function () {
+      let i =
+        arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+      (Oe(i), (he = !0));
+    }),
+    (n.clearConfig = function () {
+      ((H = null), (he = !1));
+    }),
+    (n.isValidAttribute = function (i, e, t) {
+      H || Oe({});
+      const o = d(i),
+        c = d(e);
+      return nt(o, c, t);
+    }),
+    (n.addHook = function (i, e) {
+      typeof e == "function" && q(h[i], e);
+    }),
+    (n.removeHook = function (i, e) {
+      if (e !== void 0) {
+        const t = Kt(h[i], e);
+        return t === -1 ? void 0 : Zt(h[i], t, 1)[0];
+      }
+      return lt(h[i]);
+    }),
+    (n.removeHooks = function (i) {
+      h[i] = [];
+    }),
+    (n.removeAllHooks = function () {
+      h = Tt();
+    }),
+    n
+  );
+}
+var St = At();
+const gn = Object.freeze(
+  Object.defineProperty({ __proto__: null, default: St }, Symbol.toStringTag, {
+    value: "Module",
+  }),
+);
+function G(a = "") {
+  return a == null ? "" : St(window).sanitize(String(a));
+}
+function Rt() {
+  return new Date().toLocaleString();
+}
+function Tn(a = 0) {
+  const n = Math.round(a / 1e3),
+    s = Math.floor(n / 60),
+    r = n % 60;
+  return `${s} ${s === 1 ? "Minute" : "Minutes"} and ${r} ${r === 1 ? "Second" : "Seconds"}`;
+}
+function _n(a = {}, ...n) {
+  const s = (r) => r && typeof r == "object" && !Array.isArray(r);
+  for (const r of n)
+    if (s(r))
+      for (const [f, y] of Object.entries(r))
+        s(y) ? (a[f] = _n(s(a[f]) ? a[f] : {}, y)) : (a[f] = y);
+  return a;
+}
+function hn(a) {
+  document.getElementById("result").innerHTML = G(`
+    <div class="card">
+      <div class="card__header">
+        <h2 class="card__title">Looking up demographics…</h2>
+        <span class="updated">Started ${Rt()}</span>
+      </div>
+      ${a ? `<p class="note">Address: <strong>${G(a)}</strong></p>` : ""}
+      <div class="callout">Fetching county, languages, English proficiency, population, income, DAC, and alerts…</div>
+      <p class="note">Elapsed: <span id="searchTimer">0m 00s</span></p>
+    </div>
+  `);
+}
+function An(a, n, s) {
+  document.getElementById("result").innerHTML = G(`
+    <div class="card" role="alert">
+      <div class="card__header">
+        <h2 class="card__title">Unable to retrieve data</h2>
+        <span class="updated">${Rt()}</span>
+      </div>
+      ${n ? `<p class="note">Address: <strong>${G(n)}</strong></p>` : ""}
+      <div class="callout" style="border-left-color:#b45309;">
+        ${G(a || "Please try again with a different address.")}
+      </div>
+      <p class="note">Search took ${Tn(s)}.</p>
+      <p class="note">API base: <code>${G(jt || "/api")}</code>.</p>
+    </div>
+  `);
+}
+export { hn as a, _n as d, Tn as f, Rt as n, gn as p, An as r, G as s };

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,1944 +1,437 @@
-import { _ as un } from "./pdf.js";
+import { _ as Gt } from "./pdf.js";
+import { l as Et, s as ge, f as tt, b as at, m as M } from "./maps.js";
 import {
-  A as Rn,
-  l as De,
-  s as Cn,
-  f as ie,
-  b as he,
-  m as st,
-} from "./maps.js";
-/*! @license DOMPurify 3.2.6 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.6/LICENSE */ const {
-  entries: pn,
-  setPrototypeOf: je,
-  isFrozen: Ln,
-  getPrototypeOf: Dn,
-  getOwnPropertyDescriptor: On,
-} = Object;
-let { freeze: tt, seal: it, create: fn } = Object,
-  { apply: Re, construct: Ce } = typeof Reflect < "u" && Reflect;
-tt ||
-  (tt = function (n) {
-    return n;
-  });
-it ||
-  (it = function (n) {
-    return n;
-  });
-Re ||
-  (Re = function (n, s, i) {
-    return n.apply(s, i);
-  });
-Ce ||
-  (Ce = function (n, s) {
-    return new n(...s);
-  });
-const pe = et(Array.prototype.forEach),
-  In = et(Array.prototype.lastIndexOf),
-  Ye = et(Array.prototype.pop),
-  Zt = et(Array.prototype.push),
-  Pn = et(Array.prototype.splice),
-  de = et(String.prototype.toLowerCase),
-  ve = et(String.prototype.toString),
-  Ve = et(String.prototype.match),
-  Jt = et(String.prototype.replace),
-  kn = et(String.prototype.indexOf),
-  Mn = et(String.prototype.trim),
-  ft = et(Object.prototype.hasOwnProperty),
-  J = et(RegExp.prototype.test),
-  Qt = $n(TypeError);
-function et(e) {
-  return function (n) {
-    n instanceof RegExp && (n.lastIndex = 0);
-    for (
-      var s = arguments.length, i = new Array(s > 1 ? s - 1 : 0), o = 1;
-      o < s;
-      o++
-    )
-      i[o - 1] = arguments[o];
-    return Re(e, n, i);
-  };
-}
-function $n(e) {
-  return function () {
-    for (var n = arguments.length, s = new Array(n), i = 0; i < n; i++)
-      s[i] = arguments[i];
-    return Ce(e, s);
-  };
-}
-function N(e, n) {
-  let s = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : de;
-  je && je(e, null);
-  let i = n.length;
-  for (; i--; ) {
-    let o = n[i];
-    if (typeof o == "string") {
-      const l = s(o);
-      l !== o && (Ln(n) || (n[i] = l), (o = l));
-    }
-    e[o] = !0;
-  }
-  return e;
-}
-function Fn(e) {
-  for (let n = 0; n < e.length; n++) ft(e, n) || (e[n] = null);
-  return e;
-}
-function yt(e) {
-  const n = fn(null);
-  for (const [s, i] of pn(e))
-    ft(e, s) &&
-      (Array.isArray(i)
-        ? (n[s] = Fn(i))
-        : i && typeof i == "object" && i.constructor === Object
-          ? (n[s] = yt(i))
-          : (n[s] = i));
-  return n;
-}
-function te(e, n) {
-  for (; e !== null; ) {
-    const i = On(e, n);
-    if (i) {
-      if (i.get) return et(i.get);
-      if (typeof i.value == "function") return et(i.value);
-    }
-    e = Dn(e);
-  }
-  function s() {
-    return null;
-  }
-  return s;
-}
-const Xe = tt([
-    "a",
-    "abbr",
-    "acronym",
-    "address",
-    "area",
-    "article",
-    "aside",
-    "audio",
-    "b",
-    "bdi",
-    "bdo",
-    "big",
-    "blink",
-    "blockquote",
-    "body",
-    "br",
-    "button",
-    "canvas",
-    "caption",
-    "center",
-    "cite",
-    "code",
-    "col",
-    "colgroup",
-    "content",
-    "data",
-    "datalist",
-    "dd",
-    "decorator",
-    "del",
-    "details",
-    "dfn",
-    "dialog",
-    "dir",
-    "div",
-    "dl",
-    "dt",
-    "element",
-    "em",
-    "fieldset",
-    "figcaption",
-    "figure",
-    "font",
-    "footer",
-    "form",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "head",
-    "header",
-    "hgroup",
-    "hr",
-    "html",
-    "i",
-    "img",
-    "input",
-    "ins",
-    "kbd",
-    "label",
-    "legend",
-    "li",
-    "main",
-    "map",
-    "mark",
-    "marquee",
-    "menu",
-    "menuitem",
-    "meter",
-    "nav",
-    "nobr",
-    "ol",
-    "optgroup",
-    "option",
-    "output",
-    "p",
-    "picture",
-    "pre",
-    "progress",
-    "q",
-    "rp",
-    "rt",
-    "ruby",
-    "s",
-    "samp",
-    "section",
-    "select",
-    "shadow",
-    "small",
-    "source",
-    "spacer",
-    "span",
-    "strike",
-    "strong",
-    "style",
-    "sub",
-    "summary",
-    "sup",
-    "table",
-    "tbody",
-    "td",
-    "template",
-    "textarea",
-    "tfoot",
-    "th",
-    "thead",
-    "time",
-    "tr",
-    "track",
-    "tt",
-    "u",
-    "ul",
-    "var",
-    "video",
-    "wbr",
-  ]),
-  Ee = tt([
-    "svg",
-    "a",
-    "altglyph",
-    "altglyphdef",
-    "altglyphitem",
-    "animatecolor",
-    "animatemotion",
-    "animatetransform",
-    "circle",
-    "clippath",
-    "defs",
-    "desc",
-    "ellipse",
-    "filter",
-    "font",
-    "g",
-    "glyph",
-    "glyphref",
-    "hkern",
-    "image",
-    "line",
-    "lineargradient",
-    "marker",
-    "mask",
-    "metadata",
-    "mpath",
-    "path",
-    "pattern",
-    "polygon",
-    "polyline",
-    "radialgradient",
-    "rect",
-    "stop",
-    "style",
-    "switch",
-    "symbol",
-    "text",
-    "textpath",
-    "title",
-    "tref",
-    "tspan",
-    "view",
-    "vkern",
-  ]),
-  we = tt([
-    "feBlend",
-    "feColorMatrix",
-    "feComponentTransfer",
-    "feComposite",
-    "feConvolveMatrix",
-    "feDiffuseLighting",
-    "feDisplacementMap",
-    "feDistantLight",
-    "feDropShadow",
-    "feFlood",
-    "feFuncA",
-    "feFuncB",
-    "feFuncG",
-    "feFuncR",
-    "feGaussianBlur",
-    "feImage",
-    "feMerge",
-    "feMergeNode",
-    "feMorphology",
-    "feOffset",
-    "fePointLight",
-    "feSpecularLighting",
-    "feSpotLight",
-    "feTile",
-    "feTurbulence",
-  ]),
-  xn = tt([
-    "animate",
-    "color-profile",
-    "cursor",
-    "discard",
-    "font-face",
-    "font-face-format",
-    "font-face-name",
-    "font-face-src",
-    "font-face-uri",
-    "foreignobject",
-    "hatch",
-    "hatchpath",
-    "mesh",
-    "meshgradient",
-    "meshpatch",
-    "meshrow",
-    "missing-glyph",
-    "script",
-    "set",
-    "solidcolor",
-    "unknown",
-    "use",
-  ]),
-  Te = tt([
-    "math",
-    "menclose",
-    "merror",
-    "mfenced",
-    "mfrac",
-    "mglyph",
-    "mi",
-    "mlabeledtr",
-    "mmultiscripts",
-    "mn",
-    "mo",
-    "mover",
-    "mpadded",
-    "mphantom",
-    "mroot",
-    "mrow",
-    "ms",
-    "mspace",
-    "msqrt",
-    "mstyle",
-    "msub",
-    "msup",
-    "msubsup",
-    "mtable",
-    "mtd",
-    "mtext",
-    "mtr",
-    "munder",
-    "munderover",
-    "mprescripts",
-  ]),
-  Un = tt([
-    "maction",
-    "maligngroup",
-    "malignmark",
-    "mlongdiv",
-    "mscarries",
-    "mscarry",
-    "msgroup",
-    "mstack",
-    "msline",
-    "msrow",
-    "semantics",
-    "annotation",
-    "annotation-xml",
-    "mprescripts",
-    "none",
-  ]),
-  qe = tt(["#text"]),
-  Ke = tt([
-    "accept",
-    "action",
-    "align",
-    "alt",
-    "autocapitalize",
-    "autocomplete",
-    "autopictureinpicture",
-    "autoplay",
-    "background",
-    "bgcolor",
-    "border",
-    "capture",
-    "cellpadding",
-    "cellspacing",
-    "checked",
-    "cite",
-    "class",
-    "clear",
-    "color",
-    "cols",
-    "colspan",
-    "controls",
-    "controlslist",
-    "coords",
-    "crossorigin",
-    "datetime",
-    "decoding",
-    "default",
-    "dir",
-    "disabled",
-    "disablepictureinpicture",
-    "disableremoteplayback",
-    "download",
-    "draggable",
-    "enctype",
-    "enterkeyhint",
-    "face",
-    "for",
-    "headers",
-    "height",
-    "hidden",
-    "high",
-    "href",
-    "hreflang",
-    "id",
-    "inputmode",
-    "integrity",
-    "ismap",
-    "kind",
-    "label",
-    "lang",
-    "list",
-    "loading",
-    "loop",
-    "low",
-    "max",
-    "maxlength",
-    "media",
-    "method",
-    "min",
-    "minlength",
-    "multiple",
-    "muted",
-    "name",
-    "nonce",
-    "noshade",
-    "novalidate",
-    "nowrap",
-    "open",
-    "optimum",
-    "pattern",
-    "placeholder",
-    "playsinline",
-    "popover",
-    "popovertarget",
-    "popovertargetaction",
-    "poster",
-    "preload",
-    "pubdate",
-    "radiogroup",
-    "readonly",
-    "rel",
-    "required",
-    "rev",
-    "reversed",
-    "role",
-    "rows",
-    "rowspan",
-    "spellcheck",
-    "scope",
-    "selected",
-    "shape",
-    "size",
-    "sizes",
-    "span",
-    "srclang",
-    "start",
-    "src",
-    "srcset",
-    "step",
-    "style",
-    "summary",
-    "tabindex",
-    "title",
-    "translate",
-    "type",
-    "usemap",
-    "valign",
-    "value",
-    "width",
-    "wrap",
-    "xmlns",
-    "slot",
-  ]),
-  Se = tt([
-    "accent-height",
-    "accumulate",
-    "additive",
-    "alignment-baseline",
-    "amplitude",
-    "ascent",
-    "attributename",
-    "attributetype",
-    "azimuth",
-    "basefrequency",
-    "baseline-shift",
-    "begin",
-    "bias",
-    "by",
-    "class",
-    "clip",
-    "clippathunits",
-    "clip-path",
-    "clip-rule",
-    "color",
-    "color-interpolation",
-    "color-interpolation-filters",
-    "color-profile",
-    "color-rendering",
-    "cx",
-    "cy",
-    "d",
-    "dx",
-    "dy",
-    "diffuseconstant",
-    "direction",
-    "display",
-    "divisor",
-    "dur",
-    "edgemode",
-    "elevation",
-    "end",
-    "exponent",
-    "fill",
-    "fill-opacity",
-    "fill-rule",
-    "filter",
-    "filterunits",
-    "flood-color",
-    "flood-opacity",
-    "font-family",
-    "font-size",
-    "font-size-adjust",
-    "font-stretch",
-    "font-style",
-    "font-variant",
-    "font-weight",
-    "fx",
-    "fy",
-    "g1",
-    "g2",
-    "glyph-name",
-    "glyphref",
-    "gradientunits",
-    "gradienttransform",
-    "height",
-    "href",
-    "id",
-    "image-rendering",
-    "in",
-    "in2",
-    "intercept",
-    "k",
-    "k1",
-    "k2",
-    "k3",
-    "k4",
-    "kerning",
-    "keypoints",
-    "keysplines",
-    "keytimes",
-    "lang",
-    "lengthadjust",
-    "letter-spacing",
-    "kernelmatrix",
-    "kernelunitlength",
-    "lighting-color",
-    "local",
-    "marker-end",
-    "marker-mid",
-    "marker-start",
-    "markerheight",
-    "markerunits",
-    "markerwidth",
-    "maskcontentunits",
-    "maskunits",
-    "max",
-    "mask",
-    "media",
-    "method",
-    "mode",
-    "min",
-    "name",
-    "numoctaves",
-    "offset",
-    "operator",
-    "opacity",
-    "order",
-    "orient",
-    "orientation",
-    "origin",
-    "overflow",
-    "paint-order",
-    "path",
-    "pathlength",
-    "patterncontentunits",
-    "patterntransform",
-    "patternunits",
-    "points",
-    "preservealpha",
-    "preserveaspectratio",
-    "primitiveunits",
-    "r",
-    "rx",
-    "ry",
-    "radius",
-    "refx",
-    "refy",
-    "repeatcount",
-    "repeatdur",
-    "restart",
-    "result",
-    "rotate",
-    "scale",
-    "seed",
-    "shape-rendering",
-    "slope",
-    "specularconstant",
-    "specularexponent",
-    "spreadmethod",
-    "startoffset",
-    "stddeviation",
-    "stitchtiles",
-    "stop-color",
-    "stop-opacity",
-    "stroke-dasharray",
-    "stroke-dashoffset",
-    "stroke-linecap",
-    "stroke-linejoin",
-    "stroke-miterlimit",
-    "stroke-opacity",
-    "stroke",
-    "stroke-width",
-    "style",
-    "surfacescale",
-    "systemlanguage",
-    "tabindex",
-    "tablevalues",
-    "targetx",
-    "targety",
-    "transform",
-    "transform-origin",
-    "text-anchor",
-    "text-decoration",
-    "text-rendering",
-    "textlength",
-    "type",
-    "u1",
-    "u2",
-    "unicode",
-    "values",
-    "viewbox",
-    "visibility",
-    "version",
-    "vert-adv-y",
-    "vert-origin-x",
-    "vert-origin-y",
-    "width",
-    "word-spacing",
-    "wrap",
-    "writing-mode",
-    "xchannelselector",
-    "ychannelselector",
-    "x",
-    "x1",
-    "x2",
-    "xmlns",
-    "y",
-    "y1",
-    "y2",
-    "z",
-    "zoomandpan",
-  ]),
-  Ze = tt([
-    "accent",
-    "accentunder",
-    "align",
-    "bevelled",
-    "close",
-    "columnsalign",
-    "columnlines",
-    "columnspan",
-    "denomalign",
-    "depth",
-    "dir",
-    "display",
-    "displaystyle",
-    "encoding",
-    "fence",
-    "frame",
-    "height",
-    "href",
-    "id",
-    "largeop",
-    "length",
-    "linethickness",
-    "lspace",
-    "lquote",
-    "mathbackground",
-    "mathcolor",
-    "mathsize",
-    "mathvariant",
-    "maxsize",
-    "minsize",
-    "movablelimits",
-    "notation",
-    "numalign",
-    "open",
-    "rowalign",
-    "rowlines",
-    "rowspacing",
-    "rowspan",
-    "rspace",
-    "rquote",
-    "scriptlevel",
-    "scriptminsize",
-    "scriptsizemultiplier",
-    "selection",
-    "separator",
-    "separators",
-    "stretchy",
-    "subscriptshift",
-    "supscriptshift",
-    "symmetric",
-    "voffset",
-    "width",
-    "xmlns",
-  ]),
-  fe = tt(["xlink:href", "xml:id", "xlink:title", "xml:space", "xmlns:xlink"]),
-  Hn = it(/\{\{[\w\W]*|[\w\W]*\}\}/gm),
-  Bn = it(/<%[\w\W]*|[\w\W]*%>/gm),
-  Wn = it(/\$\{[\w\W]*/gm),
-  Gn = it(/^data-[\-\w.\u00B7-\uFFFF]+$/),
-  zn = it(/^aria-[\-\w]+$/),
-  dn = it(
-    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-  ),
-  jn = it(/^(?:\w+script|data):/i),
-  Yn = it(/[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g),
-  mn = it(/^html$/i),
-  Vn = it(/^[a-z][.\w]*(-[.\w]+)+$/i);
-var Je = Object.freeze({
-  __proto__: null,
-  ARIA_ATTR: zn,
-  ATTR_WHITESPACE: Yn,
-  CUSTOM_ELEMENT: Vn,
-  DATA_ATTR: Gn,
-  DOCTYPE_NAME: mn,
-  ERB_EXPR: Bn,
-  IS_ALLOWED_URI: dn,
-  IS_SCRIPT_OR_DATA: jn,
-  MUSTACHE_EXPR: Hn,
-  TMPLIT_EXPR: Wn,
-});
-const ee = {
-    element: 1,
-    text: 3,
-    progressingInstruction: 7,
-    comment: 8,
-    document: 9,
-  },
-  Xn = function () {
-    return typeof window > "u" ? null : window;
-  },
-  qn = function (n, s) {
-    if (typeof n != "object" || typeof n.createPolicy != "function")
-      return null;
-    let i = null;
-    const o = "data-tt-policy-suffix";
-    s && s.hasAttribute(o) && (i = s.getAttribute(o));
-    const l = "dompurify" + (i ? "#" + i : "");
-    try {
-      return n.createPolicy(l, {
-        createHTML(a) {
-          return a;
-        },
-        createScriptURL(a) {
-          return a;
-        },
-      });
-    } catch {
-      return (
-        console.warn("TrustedTypes policy " + l + " could not be created."),
-        null
-      );
-    }
-  },
-  Qe = function () {
-    return {
-      afterSanitizeAttributes: [],
-      afterSanitizeElements: [],
-      afterSanitizeShadowDOM: [],
-      beforeSanitizeAttributes: [],
-      beforeSanitizeElements: [],
-      beforeSanitizeShadowDOM: [],
-      uponSanitizeAttribute: [],
-      uponSanitizeElement: [],
-      uponSanitizeShadowNode: [],
-    };
-  };
-function hn() {
-  let e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : Xn();
-  const n = (T) => hn(T);
-  if (
-    ((n.version = "3.2.6"),
-    (n.removed = []),
-    !e || !e.document || e.document.nodeType !== ee.document || !e.Element)
-  )
-    return ((n.isSupported = !1), n);
-  let { document: s } = e;
-  const i = s,
-    o = i.currentScript,
-    {
-      DocumentFragment: l,
-      HTMLTemplateElement: a,
-      Node: r,
-      Element: f,
-      NodeFilter: d,
-      NamedNodeMap: c = e.NamedNodeMap || e.MozNamedAttrMap,
-      HTMLFormElement: y,
-      DOMParser: v,
-      trustedTypes: h,
-    } = e,
-    m = f.prototype,
-    E = te(m, "cloneNode"),
-    _ = te(m, "remove"),
-    u = te(m, "nextSibling"),
-    g = te(m, "childNodes"),
-    w = te(m, "parentNode");
-  if (typeof a == "function") {
-    const T = s.createElement("template");
-    T.content && T.content.ownerDocument && (s = T.content.ownerDocument);
-  }
-  let b,
-    R = "";
-  const {
-      implementation: U,
-      createNodeIterator: $,
-      createDocumentFragment: j,
-      getElementsByTagName: G,
-    } = s,
-    { importNode: Z } = i;
-  let C = Qe();
-  n.isSupported =
-    typeof pn == "function" &&
-    typeof w == "function" &&
-    U &&
-    U.createHTMLDocument !== void 0;
-  const {
-    MUSTACHE_EXPR: L,
-    ERB_EXPR: Y,
-    TMPLIT_EXPR: ot,
-    DATA_ATTR: z,
-    ARIA_ATTR: at,
-    IS_SCRIPT_OR_DATA: rt,
-    ATTR_WHITESPACE: ct,
-    CUSTOM_ELEMENT: lt,
-  } = Je;
-  let { IS_ALLOWED_URI: Dt } = Je,
-    F = null;
-  const ae = N({}, [...Xe, ...Ee, ...we, ...Te, ...qe]);
-  let H = null;
-  const re = N({}, [...Ke, ...Se, ...Ze, ...fe]);
-  let I = Object.seal(
-      fn(null, {
-        tagNameCheck: {
-          writable: !0,
-          configurable: !1,
-          enumerable: !0,
-          value: null,
-        },
-        attributeNameCheck: {
-          writable: !0,
-          configurable: !1,
-          enumerable: !0,
-          value: null,
-        },
-        allowCustomizedBuiltInElements: {
-          writable: !0,
-          configurable: !1,
-          enumerable: !0,
-          value: !1,
-        },
-      }),
-    ),
-    bt = null,
-    Ot = null,
-    Bt = !0,
-    Wt = !0,
-    Gt = !1,
-    x = !0,
-    D = !1,
-    Nt = !0,
-    dt = !1,
-    zt = !1,
-    jt = !1,
-    At = !1,
-    It = !1,
-    Pt = !1,
-    ce = !0,
-    le = !1;
-  const _e = "user-content-";
-  let Rt = !0,
-    Ct = !1,
-    mt = {},
-    vt = null;
-  const kt = N({}, [
-    "annotation-xml",
-    "audio",
-    "colgroup",
-    "desc",
-    "foreignobject",
-    "head",
-    "iframe",
-    "math",
-    "mi",
-    "mn",
-    "mo",
-    "ms",
-    "mtext",
-    "noembed",
-    "noframes",
-    "noscript",
-    "plaintext",
-    "script",
-    "style",
-    "svg",
-    "template",
-    "thead",
-    "title",
-    "video",
-    "xmp",
-  ]);
-  let ue = null;
-  const Mt = N({}, ["audio", "video", "img", "source", "image", "track"]);
-  let Yt = null;
-  const $t = N({}, [
-      "alt",
-      "class",
-      "for",
-      "id",
-      "label",
-      "name",
-      "pattern",
-      "placeholder",
-      "role",
-      "summary",
-      "title",
-      "value",
-      "style",
-      "xmlns",
-    ]),
-    Ft = "http://www.w3.org/1998/Math/MathML",
-    Et = "http://www.w3.org/2000/svg",
-    ut = "http://www.w3.org/1999/xhtml";
-  let wt = ut,
-    Vt = !1,
-    Xt = null;
-  const S = N({}, [Ft, Et, ut], ve);
-  let V = N({}, ["mi", "mo", "mn", "ms", "mtext"]),
-    B = N({}, ["annotation-xml"]);
-  const X = N({}, ["title", "style", "font", "a", "script"]);
-  let pt = null;
-  const qt = ["application/xhtml+xml", "text/html"],
-    Lt = "text/html";
-  let P = null,
-    Tt = null;
-  const Sn = s.createElement("form"),
-    Pe = function (t) {
-      return t instanceof RegExp || t instanceof Function;
-    },
-    ge = function () {
-      let t =
-        arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
-      if (!(Tt && Tt === t)) {
-        if (
-          ((!t || typeof t != "object") && (t = {}),
-          (t = yt(t)),
-          (pt =
-            qt.indexOf(t.PARSER_MEDIA_TYPE) === -1 ? Lt : t.PARSER_MEDIA_TYPE),
-          (P = pt === "application/xhtml+xml" ? ve : de),
-          (F = ft(t, "ALLOWED_TAGS") ? N({}, t.ALLOWED_TAGS, P) : ae),
-          (H = ft(t, "ALLOWED_ATTR") ? N({}, t.ALLOWED_ATTR, P) : re),
-          (Xt = ft(t, "ALLOWED_NAMESPACES")
-            ? N({}, t.ALLOWED_NAMESPACES, ve)
-            : S),
-          (Yt = ft(t, "ADD_URI_SAFE_ATTR")
-            ? N(yt($t), t.ADD_URI_SAFE_ATTR, P)
-            : $t),
-          (ue = ft(t, "ADD_DATA_URI_TAGS")
-            ? N(yt(Mt), t.ADD_DATA_URI_TAGS, P)
-            : Mt),
-          (vt = ft(t, "FORBID_CONTENTS") ? N({}, t.FORBID_CONTENTS, P) : kt),
-          (bt = ft(t, "FORBID_TAGS") ? N({}, t.FORBID_TAGS, P) : yt({})),
-          (Ot = ft(t, "FORBID_ATTR") ? N({}, t.FORBID_ATTR, P) : yt({})),
-          (mt = ft(t, "USE_PROFILES") ? t.USE_PROFILES : !1),
-          (Bt = t.ALLOW_ARIA_ATTR !== !1),
-          (Wt = t.ALLOW_DATA_ATTR !== !1),
-          (Gt = t.ALLOW_UNKNOWN_PROTOCOLS || !1),
-          (x = t.ALLOW_SELF_CLOSE_IN_ATTR !== !1),
-          (D = t.SAFE_FOR_TEMPLATES || !1),
-          (Nt = t.SAFE_FOR_XML !== !1),
-          (dt = t.WHOLE_DOCUMENT || !1),
-          (At = t.RETURN_DOM || !1),
-          (It = t.RETURN_DOM_FRAGMENT || !1),
-          (Pt = t.RETURN_TRUSTED_TYPE || !1),
-          (jt = t.FORCE_BODY || !1),
-          (ce = t.SANITIZE_DOM !== !1),
-          (le = t.SANITIZE_NAMED_PROPS || !1),
-          (Rt = t.KEEP_CONTENT !== !1),
-          (Ct = t.IN_PLACE || !1),
-          (Dt = t.ALLOWED_URI_REGEXP || dn),
-          (wt = t.NAMESPACE || ut),
-          (V = t.MATHML_TEXT_INTEGRATION_POINTS || V),
-          (B = t.HTML_INTEGRATION_POINTS || B),
-          (I = t.CUSTOM_ELEMENT_HANDLING || {}),
-          t.CUSTOM_ELEMENT_HANDLING &&
-            Pe(t.CUSTOM_ELEMENT_HANDLING.tagNameCheck) &&
-            (I.tagNameCheck = t.CUSTOM_ELEMENT_HANDLING.tagNameCheck),
-          t.CUSTOM_ELEMENT_HANDLING &&
-            Pe(t.CUSTOM_ELEMENT_HANDLING.attributeNameCheck) &&
-            (I.attributeNameCheck =
-              t.CUSTOM_ELEMENT_HANDLING.attributeNameCheck),
-          t.CUSTOM_ELEMENT_HANDLING &&
-            typeof t.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements ==
-              "boolean" &&
-            (I.allowCustomizedBuiltInElements =
-              t.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements),
-          D && (Wt = !1),
-          It && (At = !0),
-          mt &&
-            ((F = N({}, qe)),
-            (H = []),
-            mt.html === !0 && (N(F, Xe), N(H, Ke)),
-            mt.svg === !0 && (N(F, Ee), N(H, Se), N(H, fe)),
-            mt.svgFilters === !0 && (N(F, we), N(H, Se), N(H, fe)),
-            mt.mathMl === !0 && (N(F, Te), N(H, Ze), N(H, fe))),
-          t.ADD_TAGS && (F === ae && (F = yt(F)), N(F, t.ADD_TAGS, P)),
-          t.ADD_ATTR && (H === re && (H = yt(H)), N(H, t.ADD_ATTR, P)),
-          t.ADD_URI_SAFE_ATTR && N(Yt, t.ADD_URI_SAFE_ATTR, P),
-          t.FORBID_CONTENTS &&
-            (vt === kt && (vt = yt(vt)), N(vt, t.FORBID_CONTENTS, P)),
-          Rt && (F["#text"] = !0),
-          dt && N(F, ["html", "head", "body"]),
-          F.table && (N(F, ["tbody"]), delete bt.tbody),
-          t.TRUSTED_TYPES_POLICY)
-        ) {
-          if (typeof t.TRUSTED_TYPES_POLICY.createHTML != "function")
-            throw Qt(
-              'TRUSTED_TYPES_POLICY configuration option must provide a "createHTML" hook.',
-            );
-          if (typeof t.TRUSTED_TYPES_POLICY.createScriptURL != "function")
-            throw Qt(
-              'TRUSTED_TYPES_POLICY configuration option must provide a "createScriptURL" hook.',
-            );
-          ((b = t.TRUSTED_TYPES_POLICY), (R = b.createHTML("")));
-        } else
-          (b === void 0 && (b = qn(h, o)),
-            b !== null && typeof R == "string" && (R = b.createHTML("")));
-        (tt && tt(t), (Tt = t));
-      }
-    },
-    ke = N({}, [...Ee, ...we, ...xn]),
-    Me = N({}, [...Te, ...Un]),
-    bn = function (t) {
-      let p = w(t);
-      (!p || !p.tagName) && (p = { namespaceURI: wt, tagName: "template" });
-      const A = de(t.tagName),
-        O = de(p.tagName);
-      return Xt[t.namespaceURI]
-        ? t.namespaceURI === Et
-          ? p.namespaceURI === ut
-            ? A === "svg"
-            : p.namespaceURI === Ft
-              ? A === "svg" && (O === "annotation-xml" || V[O])
-              : !!ke[A]
-          : t.namespaceURI === Ft
-            ? p.namespaceURI === ut
-              ? A === "math"
-              : p.namespaceURI === Et
-                ? A === "math" && B[O]
-                : !!Me[A]
-            : t.namespaceURI === ut
-              ? (p.namespaceURI === Et && !B[O]) ||
-                (p.namespaceURI === Ft && !V[O])
-                ? !1
-                : !Me[A] && (X[A] || !ke[A])
-              : !!(pt === "application/xhtml+xml" && Xt[t.namespaceURI])
-        : !1;
-    },
-    ht = function (t) {
-      Zt(n.removed, { element: t });
-      try {
-        w(t).removeChild(t);
-      } catch {
-        _(t);
-      }
-    },
-    xt = function (t, p) {
-      try {
-        Zt(n.removed, { attribute: p.getAttributeNode(t), from: p });
-      } catch {
-        Zt(n.removed, { attribute: null, from: p });
-      }
-      if ((p.removeAttribute(t), t === "is"))
-        if (At || It)
-          try {
-            ht(p);
-          } catch {}
-        else
-          try {
-            p.setAttribute(t, "");
-          } catch {}
-    },
-    $e = function (t) {
-      let p = null,
-        A = null;
-      if (jt) t = "<remove></remove>" + t;
-      else {
-        const W = Ve(t, /^[\r\n\t ]+/);
-        A = W && W[0];
-      }
-      pt === "application/xhtml+xml" &&
-        wt === ut &&
-        (t =
-          '<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>' +
-          t +
-          "</body></html>");
-      const O = b ? b.createHTML(t) : t;
-      if (wt === ut)
-        try {
-          p = new v().parseFromString(O, pt);
-        } catch {}
-      if (!p || !p.documentElement) {
-        p = U.createDocument(wt, "template", null);
-        try {
-          p.documentElement.innerHTML = Vt ? R : O;
-        } catch {}
-      }
-      const q = p.body || p.documentElement;
-      return (
-        t && A && q.insertBefore(s.createTextNode(A), q.childNodes[0] || null),
-        wt === ut
-          ? G.call(p, dt ? "html" : "body")[0]
-          : dt
-            ? p.documentElement
-            : q
-      );
-    },
-    Fe = function (t) {
-      return $.call(
-        t.ownerDocument || t,
-        t,
-        d.SHOW_ELEMENT |
-          d.SHOW_COMMENT |
-          d.SHOW_TEXT |
-          d.SHOW_PROCESSING_INSTRUCTION |
-          d.SHOW_CDATA_SECTION,
-        null,
-      );
-    },
-    ye = function (t) {
-      return (
-        t instanceof y &&
-        (typeof t.nodeName != "string" ||
-          typeof t.textContent != "string" ||
-          typeof t.removeChild != "function" ||
-          !(t.attributes instanceof c) ||
-          typeof t.removeAttribute != "function" ||
-          typeof t.setAttribute != "function" ||
-          typeof t.namespaceURI != "string" ||
-          typeof t.insertBefore != "function" ||
-          typeof t.hasChildNodes != "function")
-      );
-    },
-    xe = function (t) {
-      return typeof r == "function" && t instanceof r;
-    };
-  function _t(T, t, p) {
-    pe(T, (A) => {
-      A.call(n, t, p, Tt);
-    });
-  }
-  const Ue = function (t) {
-      let p = null;
-      if ((_t(C.beforeSanitizeElements, t, null), ye(t))) return (ht(t), !0);
-      const A = P(t.nodeName);
-      if (
-        (_t(C.uponSanitizeElement, t, { tagName: A, allowedTags: F }),
-        (Nt &&
-          t.hasChildNodes() &&
-          !xe(t.firstElementChild) &&
-          J(/<[/\w!]/g, t.innerHTML) &&
-          J(/<[/\w!]/g, t.textContent)) ||
-          t.nodeType === ee.progressingInstruction ||
-          (Nt && t.nodeType === ee.comment && J(/<[/\w]/g, t.data)))
-      )
-        return (ht(t), !0);
-      if (!F[A] || bt[A]) {
-        if (
-          !bt[A] &&
-          Be(A) &&
-          ((I.tagNameCheck instanceof RegExp && J(I.tagNameCheck, A)) ||
-            (I.tagNameCheck instanceof Function && I.tagNameCheck(A)))
-        )
-          return !1;
-        if (Rt && !vt[A]) {
-          const O = w(t) || t.parentNode,
-            q = g(t) || t.childNodes;
-          if (q && O) {
-            const W = q.length;
-            for (let nt = W - 1; nt >= 0; --nt) {
-              const gt = E(q[nt], !0);
-              ((gt.__removalCount = (t.__removalCount || 0) + 1),
-                O.insertBefore(gt, u(t)));
-            }
-          }
-        }
-        return (ht(t), !0);
-      }
-      return (t instanceof f && !bn(t)) ||
-        ((A === "noscript" || A === "noembed" || A === "noframes") &&
-          J(/<\/no(script|embed|frames)/i, t.innerHTML))
-        ? (ht(t), !0)
-        : (D &&
-            t.nodeType === ee.text &&
-            ((p = t.textContent),
-            pe([L, Y, ot], (O) => {
-              p = Jt(p, O, " ");
-            }),
-            t.textContent !== p &&
-              (Zt(n.removed, { element: t.cloneNode() }), (t.textContent = p))),
-          _t(C.afterSanitizeElements, t, null),
-          !1);
-    },
-    He = function (t, p, A) {
-      if (ce && (p === "id" || p === "name") && (A in s || A in Sn)) return !1;
-      if (!(Wt && !Ot[p] && J(z, p))) {
-        if (!(Bt && J(at, p))) {
-          if (!H[p] || Ot[p]) {
-            if (
-              !(
-                (Be(t) &&
-                  ((I.tagNameCheck instanceof RegExp && J(I.tagNameCheck, t)) ||
-                    (I.tagNameCheck instanceof Function &&
-                      I.tagNameCheck(t))) &&
-                  ((I.attributeNameCheck instanceof RegExp &&
-                    J(I.attributeNameCheck, p)) ||
-                    (I.attributeNameCheck instanceof Function &&
-                      I.attributeNameCheck(p)))) ||
-                (p === "is" &&
-                  I.allowCustomizedBuiltInElements &&
-                  ((I.tagNameCheck instanceof RegExp && J(I.tagNameCheck, A)) ||
-                    (I.tagNameCheck instanceof Function && I.tagNameCheck(A))))
-              )
-            )
-              return !1;
-          } else if (!Yt[p]) {
-            if (!J(Dt, Jt(A, ct, ""))) {
-              if (
-                !(
-                  (p === "src" || p === "xlink:href" || p === "href") &&
-                  t !== "script" &&
-                  kn(A, "data:") === 0 &&
-                  ue[t]
-                )
-              ) {
-                if (!(Gt && !J(rt, Jt(A, ct, "")))) {
-                  if (A) return !1;
-                }
-              }
-            }
-          }
-        }
-      }
-      return !0;
-    },
-    Be = function (t) {
-      return t !== "annotation-xml" && Ve(t, lt);
-    },
-    We = function (t) {
-      _t(C.beforeSanitizeAttributes, t, null);
-      const { attributes: p } = t;
-      if (!p || ye(t)) return;
-      const A = {
-        attrName: "",
-        attrValue: "",
-        keepAttr: !0,
-        allowedAttributes: H,
-        forceKeepAttr: void 0,
-      };
-      let O = p.length;
-      for (; O--; ) {
-        const q = p[O],
-          { name: W, namespaceURI: nt, value: gt } = q,
-          Kt = P(W),
-          Ae = gt;
-        let K = W === "value" ? Ae : Mn(Ae);
-        if (
-          ((A.attrName = Kt),
-          (A.attrValue = K),
-          (A.keepAttr = !0),
-          (A.forceKeepAttr = void 0),
-          _t(C.uponSanitizeAttribute, t, A),
-          (K = A.attrValue),
-          le && (Kt === "id" || Kt === "name") && (xt(W, t), (K = _e + K)),
-          Nt && J(/((--!?|])>)|<\/(style|title)/i, K))
-        ) {
-          xt(W, t);
-          continue;
-        }
-        if (A.forceKeepAttr) continue;
-        if (!A.keepAttr) {
-          xt(W, t);
-          continue;
-        }
-        if (!x && J(/\/>/i, K)) {
-          xt(W, t);
-          continue;
-        }
-        D &&
-          pe([L, Y, ot], (ze) => {
-            K = Jt(K, ze, " ");
-          });
-        const Ge = P(t.nodeName);
-        if (!He(Ge, Kt, K)) {
-          xt(W, t);
-          continue;
-        }
-        if (
-          b &&
-          typeof h == "object" &&
-          typeof h.getAttributeType == "function" &&
-          !nt
-        )
-          switch (h.getAttributeType(Ge, Kt)) {
-            case "TrustedHTML": {
-              K = b.createHTML(K);
-              break;
-            }
-            case "TrustedScriptURL": {
-              K = b.createScriptURL(K);
-              break;
-            }
-          }
-        if (K !== Ae)
-          try {
-            (nt ? t.setAttributeNS(nt, W, K) : t.setAttribute(W, K),
-              ye(t) ? ht(t) : Ye(n.removed));
-          } catch {
-            xt(W, t);
-          }
-      }
-      _t(C.afterSanitizeAttributes, t, null);
-    },
-    Nn = function T(t) {
-      let p = null;
-      const A = Fe(t);
-      for (_t(C.beforeSanitizeShadowDOM, t, null); (p = A.nextNode()); )
-        (_t(C.uponSanitizeShadowNode, p, null),
-          Ue(p),
-          We(p),
-          p.content instanceof l && T(p.content));
-      _t(C.afterSanitizeShadowDOM, t, null);
-    };
-  return (
-    (n.sanitize = function (T) {
-      let t =
-          arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {},
-        p = null,
-        A = null,
-        O = null,
-        q = null;
-      if (((Vt = !T), Vt && (T = "<!-->"), typeof T != "string" && !xe(T)))
-        if (typeof T.toString == "function") {
-          if (((T = T.toString()), typeof T != "string"))
-            throw Qt("dirty is not a string, aborting");
-        } else throw Qt("toString is not a function");
-      if (!n.isSupported) return T;
-      if (
-        (zt || ge(t), (n.removed = []), typeof T == "string" && (Ct = !1), Ct)
-      ) {
-        if (T.nodeName) {
-          const gt = P(T.nodeName);
-          if (!F[gt] || bt[gt])
-            throw Qt("root node is forbidden and cannot be sanitized in-place");
-        }
-      } else if (T instanceof r)
-        ((p = $e("<!---->")),
-          (A = p.ownerDocument.importNode(T, !0)),
-          (A.nodeType === ee.element && A.nodeName === "BODY") ||
-          A.nodeName === "HTML"
-            ? (p = A)
-            : p.appendChild(A));
-      else {
-        if (!At && !D && !dt && T.indexOf("<") === -1)
-          return b && Pt ? b.createHTML(T) : T;
-        if (((p = $e(T)), !p)) return At ? null : Pt ? R : "";
-      }
-      p && jt && ht(p.firstChild);
-      const W = Fe(Ct ? T : p);
-      for (; (O = W.nextNode()); )
-        (Ue(O), We(O), O.content instanceof l && Nn(O.content));
-      if (Ct) return T;
-      if (At) {
-        if (It)
-          for (q = j.call(p.ownerDocument); p.firstChild; )
-            q.appendChild(p.firstChild);
-        else q = p;
-        return (
-          (H.shadowroot || H.shadowrootmode) && (q = Z.call(i, q, !0)),
-          q
-        );
-      }
-      let nt = dt ? p.outerHTML : p.innerHTML;
-      return (
-        dt &&
-          F["!doctype"] &&
-          p.ownerDocument &&
-          p.ownerDocument.doctype &&
-          p.ownerDocument.doctype.name &&
-          J(mn, p.ownerDocument.doctype.name) &&
-          (nt =
-            "<!DOCTYPE " +
-            p.ownerDocument.doctype.name +
-            `>
-` +
-            nt),
-        D &&
-          pe([L, Y, ot], (gt) => {
-            nt = Jt(nt, gt, " ");
-          }),
-        b && Pt ? b.createHTML(nt) : nt
-      );
-    }),
-    (n.setConfig = function () {
-      let T =
-        arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
-      (ge(T), (zt = !0));
-    }),
-    (n.clearConfig = function () {
-      ((Tt = null), (zt = !1));
-    }),
-    (n.isValidAttribute = function (T, t, p) {
-      Tt || ge({});
-      const A = P(T),
-        O = P(t);
-      return He(A, O, p);
-    }),
-    (n.addHook = function (T, t) {
-      typeof t == "function" && Zt(C[T], t);
-    }),
-    (n.removeHook = function (T, t) {
-      if (t !== void 0) {
-        const p = In(C[T], t);
-        return p === -1 ? void 0 : Pn(C[T], p, 1)[0];
-      }
-      return Ye(C[T]);
-    }),
-    (n.removeHooks = function (T) {
-      C[T] = [];
-    }),
-    (n.removeAllHooks = function () {
-      C = Qe();
-    }),
-    n
-  );
-}
-var _n = hn();
-const _s = Object.freeze(
-  Object.defineProperty({ __proto__: null, default: _n }, Symbol.toStringTag, {
-    value: "Module",
-  }),
-);
-function k(e = "") {
-  return e == null ? "" : _n(window).sanitize(String(e));
-}
-function Oe() {
-  return new Date().toLocaleString();
-}
-function gn(e = 0) {
-  const n = Math.round(e / 1e3),
-    s = Math.floor(n / 60),
-    i = n % 60;
-  return `${s} ${s === 1 ? "Minute" : "Minutes"} and ${i} ${i === 1 ? "Second" : "Seconds"}`;
-}
-function Kn(e) {
-  document.getElementById("result").innerHTML = k(`
-    <div class="card">
-      <div class="card__header">
-        <h2 class="card__title">Looking up demographics…</h2>
-        <span class="updated">Started ${Oe()}</span>
-      </div>
-      ${e ? `<p class="note">Address: <strong>${k(e)}</strong></p>` : ""}
-      <div class="callout">Fetching county, languages, English proficiency, population, income, DAC, and alerts…</div>
-      <p class="note">Elapsed: <span id="searchTimer">0m 00s</span></p>
-    </div>
-  `);
-}
-function tn(e, n, s) {
-  document.getElementById("result").innerHTML = k(`
-    <div class="card" role="alert">
-      <div class="card__header">
-        <h2 class="card__title">Unable to retrieve data</h2>
-        <span class="updated">${Oe()}</span>
-      </div>
-      ${n ? `<p class="note">Address: <strong>${k(n)}</strong></p>` : ""}
-      <div class="callout" style="border-left-color:#b45309;">
-        ${k(e || "Please try again with a different address.")}
-      </div>
-      <p class="note">Search took ${gn(s)}.</p>
-      <p class="note">API base: <code>${k(Rn || "/api")}</code>.</p>
-    </div>
-  `);
-}
-var ln;
-const en =
-  ((ln = document.querySelector('meta[name="sentry-dsn"]')) == null
+  r as Tt,
+  a as fe,
+  d as it,
+  s as k,
+  n as ye,
+  f as ve,
+} from "./error.js";
+var Wt;
+const Rt =
+  ((Wt = document.querySelector('meta[name="sentry-dsn"]')) == null
     ? void 0
-    : ln.content) || "";
-en &&
-  un(() => import("./index.js"), [])
-    .then((e) => {
-      ((window.Sentry = e), e.init({ dsn: en }), De("Sentry initialized"));
+    : Wt.content) || "";
+Rt &&
+  Gt(() => import("./index.js"), [])
+    .then((t) => {
+      ((window.Sentry = t), t.init({ dsn: Rt }), Et("Sentry initialized"));
     })
-    .catch((e) => console.error("Sentry failed to load", e));
+    .catch((t) => console.error("Sentry failed to load", t));
 "serviceWorker" in navigator &&
   window.addEventListener("load", () => {
     navigator.serviceWorker
       .register("/sw.js")
-      .catch((e) => console.error("SW registration failed", e));
+      .catch((t) => console.error("SW registration failed", t));
   });
-window.addEventListener("error", (e) => {
-  var n;
-  (De("window.onerror", e.message),
-    (n = window.Sentry) == null ||
-      n.captureException(e.error || new Error(e.message || "Unknown error")));
+window.addEventListener("error", (t) => {
+  var s;
+  (Et("window.onerror", t.message),
+    (s = window.Sentry) == null ||
+      s.captureException(t.error || new Error(t.message || "Unknown error")));
 });
-window.addEventListener("unhandledrejection", (e) => {
-  var n;
-  (De("unhandledrejection", e.reason),
-    (n = window.Sentry) == null || n.captureException(e.reason));
+window.addEventListener("unhandledrejection", (t) => {
+  var s;
+  (Et("unhandledrejection", t.reason),
+    (s = window.Sentry) == null || s.captureException(t.reason));
 });
-let Ut = null;
-const be = new Map();
-function yn() {
+let J = null;
+const _t = new Map(),
+  gt = new Map(),
+  ft = new Map(),
+  yt = new Map(),
+  vt = new Map(),
+  wt = new Map(),
+  At = new Map();
+function jt() {
   window.print();
 }
-window.printReport = yn;
-function An() {
-  if (!Ut) return;
-  const e = new Blob([JSON.stringify(Ut, null, 2)], {
+window.printReport = jt;
+function xt() {
+  if (!J) return;
+  const t = new Blob([JSON.stringify(J, null, 2)], {
       type: "application/json",
     }),
-    n = URL.createObjectURL(e),
-    s = document.createElement("a"),
-    i = (Ut.address || "report").replace(/[^a-z0-9]+/gi, "_").toLowerCase();
-  ((s.href = n),
-    (s.download = `calwep_report_${i}.json`),
-    document.body.appendChild(s),
-    s.click(),
-    document.body.removeChild(s),
-    URL.revokeObjectURL(n));
+    s = URL.createObjectURL(t),
+    r = document.createElement("a"),
+    a = (J.address || "report").replace(/[^a-z0-9]+/gi, "_").toLowerCase();
+  ((r.href = s),
+    (r.download = `calwep_report_${a}.json`),
+    document.body.appendChild(r),
+    r.click(),
+    document.body.removeChild(r),
+    URL.revokeObjectURL(s));
 }
-window.downloadRawData = An;
+window.downloadRawData = xt;
 window.downloadPdf = async function () {
-  const { downloadPdf: e } = await un(async () => {
-    const { downloadPdf: n } = await import("./pdf.js").then((s) => s.p);
-    return { downloadPdf: n };
+  const { downloadPdf: t } = await Gt(async () => {
+    const { downloadPdf: s } = await import("./pdf.js").then((r) => r.p);
+    return { downloadPdf: s };
   }, []);
-  e(Ut);
+  t(J);
 };
-function vn() {
-  const e = window.location.href;
+function Ht() {
+  const t = window.location.href;
   navigator.clipboard && window.isSecureContext
     ? navigator.clipboard
-        .writeText(e)
+        .writeText(t)
         .then(() => alert("Link copied to clipboard"))
         .catch(() => {
-          prompt("Copy this link:", e);
+          prompt("Copy this link:", t);
         })
-    : prompt("Copy this link:", e);
+    : prompt("Copy this link:", t);
 }
-window.shareReport = vn;
-function Zn() {
-  var e, n, s, i;
-  ((e = document.getElementById("printBtn")) == null ||
-    e.addEventListener("click", yn),
-    (n = document.getElementById("pdfBtn")) == null ||
-      n.addEventListener("click", window.downloadPdf),
-    (s = document.getElementById("rawBtn")) == null ||
-      s.addEventListener("click", An),
-    (i = document.getElementById("shareBtn")) == null ||
-      i.addEventListener("click", vn));
+window.shareReport = Ht;
+function we() {
+  var t, s, r, a;
+  ((t = document.getElementById("printBtn")) == null ||
+    t.addEventListener("click", jt),
+    (s = document.getElementById("pdfBtn")) == null ||
+      s.addEventListener("click", window.downloadPdf),
+    (r = document.getElementById("rawBtn")) == null ||
+      r.addEventListener("click", xt),
+    (a = document.getElementById("shareBtn")) == null ||
+      a.addEventListener("click", Ht));
 }
-function Q(e) {
-  return e == null || Number(e) === -888888888;
+function R(t) {
+  const s = Number(t);
+  return t == null || !Number.isFinite(s) || s === -888888888;
 }
-function Jn(e) {
-  return !Q(e) && Number.isFinite(Number(e))
-    ? Number(e).toLocaleString()
-    : "Not available";
+const et = "No data available";
+function Ae(t) {
+  return !R(t) && Number.isFinite(Number(t)) ? Number(t).toLocaleString() : et;
 }
-function Ne(e) {
-  return Q(e) || !Number.isFinite(Number(e))
-    ? "Not available"
-    : `$${Math.round(Number(e)).toLocaleString()}`;
+function bt(t) {
+  return R(t) || !Number.isFinite(Number(t))
+    ? et
+    : `$${Math.round(Number(t)).toLocaleString()}`;
 }
-function nn(e) {
-  return !Q(e) && Number.isFinite(Number(e))
-    ? Number(e).toLocaleString(void 0, { maximumFractionDigits: 1 })
-    : "Not available";
+function Lt(t) {
+  return !R(t) && Number.isFinite(Number(t))
+    ? Number(t).toLocaleString(void 0, { maximumFractionDigits: 1 })
+    : et;
 }
-function M(e) {
-  return !Q(e) && Number.isFinite(Number(e))
-    ? `${Number(e).toFixed(1)}%`
-    : "Not available";
+function S(t) {
+  return !R(t) && Number.isFinite(Number(t)) ? `${Number(t).toFixed(1)}%` : et;
 }
-function se(e = {}, ...n) {
-  const s = (i) => i && typeof i == "object" && !Array.isArray(i);
-  for (const i of n)
-    if (s(i))
-      for (const [o, l] of Object.entries(i))
-        s(l) ? (e[o] = se(s(e[o]) ? e[o] : {}, l)) : (e[o] = l);
-  return e;
+function st(t = [], s = 50) {
+  const r = [];
+  for (let a = 0; a < t.length; a += s) r.push(t.slice(a, a + s));
+  return r;
 }
-function oe(e = [], n = 50) {
-  const s = [];
-  for (let i = 0; i < e.length; i += n) s.push(e.slice(i, i + n));
-  return s;
-}
-let me = null,
-  Ht = null;
-function Qn() {
-  Ht = Date.now();
-  const e = (n) => {
-    const s = document.getElementById("searchTimer");
-    s && (s.textContent = n);
-    const i = document.getElementById("spinnerTime");
-    i && (i.textContent = n);
+let rt = null,
+  Y = null;
+function be() {
+  Y = Date.now();
+  const t = (s) => {
+    const r = document.getElementById("searchTimer");
+    r && (r.textContent = s);
+    const a = document.getElementById("spinnerTime");
+    a && (a.textContent = s);
   };
-  (e("0m 00s"),
-    (me = setInterval(() => {
-      if (!Ht) return;
-      const n = Date.now() - Ht,
-        s = Math.floor((n / 1e3) % 60),
-        i = Math.floor(n / 6e4);
-      e(`${i}m ${s.toString().padStart(2, "0")}s`);
+  (t("0m 00s"),
+    (rt = setInterval(() => {
+      if (!Y) return;
+      const s = Date.now() - Y,
+        r = Math.floor((s / 1e3) % 60),
+        a = Math.floor(s / 6e4);
+      t(`${a}m ${r.toString().padStart(2, "0")}s`);
     }, 1e3)));
 }
-function sn() {
-  me && clearInterval(me);
-  const e = Ht ? Date.now() - Ht : 0;
-  return ((me = null), (Ht = null), e);
+function It() {
+  rt && clearInterval(rt);
+  const t = Y ? Date.now() - Y : 0;
+  return ((rt = null), (Y = null), t);
 }
-async function ts(e = {}) {
+async function Se(t = {}) {
   let {
-    city: n,
-    census_tract: s,
-    lat: i,
+    city: s,
+    census_tract: r,
+    lat: a,
     lon: o,
     state_fips: l,
-    county_fips: a,
-    tract_code: r,
-  } = e;
-  const f = [];
+    county_fips: e,
+    tract_code: n,
+  } = t;
+  const u = [];
   return (
-    !n &&
-      i != null &&
+    !s &&
+      a != null &&
       o != null &&
-      f.push(
+      u.push(
         fetch(
-          `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${i}&longitude=${o}&localityLanguage=en`,
+          `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${a}&longitude=${o}&localityLanguage=en`,
         )
-          .then((d) => d.json())
-          .then((d) => {
-            var y, v;
-            n =
+          .then((p) => p.json())
+          .then((p) => {
+            var m, f;
+            s =
               (Array.isArray(
-                (y = d == null ? void 0 : d.localityInfo) == null
+                (m = p == null ? void 0 : p.localityInfo) == null
                   ? void 0
-                  : y.administrative,
+                  : m.administrative,
               )
-                ? (v = d.localityInfo.administrative.find(
+                ? (f = p.localityInfo.administrative.find(
                     (h) => h.order === 8 || h.adminLevel === 8,
                   )) == null
                   ? void 0
-                  : v.name
+                  : f.name
                 : null) ||
-              d.city ||
-              d.locality ||
-              n;
+              p.city ||
+              p.locality ||
+              s;
           })
           .catch(() => {}),
       ),
-    (!s || !l || !a || !r) &&
-      i != null &&
+    (!r || !l || !e || !n) &&
+      a != null &&
       o != null &&
-      f.push(
+      u.push(
         fetch(
-          `https://geo.fcc.gov/api/census/block/find?latitude=${i}&longitude=${o}&format=json`,
+          `https://geo.fcc.gov/api/census/block/find?latitude=${a}&longitude=${o}&format=json`,
         )
-          .then((d) => d.json())
-          .then((d) => {
-            var y;
-            const c =
-              (y = d == null ? void 0 : d.Block) == null ? void 0 : y.FIPS;
-            c &&
-              c.length >= 11 &&
-              ((l = c.slice(0, 2)),
-              (a = c.slice(2, 5)),
-              (r = c.slice(5, 11)),
-              (s = `${r.slice(0, 4)}.${r.slice(4)}`));
+          .then((p) => p.json())
+          .then((p) => {
+            var m;
+            const i =
+              (m = p == null ? void 0 : p.Block) == null ? void 0 : m.FIPS;
+            i &&
+              i.length >= 11 &&
+              ((l = i.slice(0, 2)),
+              (e = i.slice(2, 5)),
+              (n = i.slice(5, 11)),
+              (r = `${n.slice(0, 4)}.${n.slice(4)}`));
           })
           .catch(() => {}),
       ),
-    f.length && (await Promise.all(f)),
+    u.length && (await Promise.all(u)),
     {
-      ...e,
-      city: n,
-      census_tract: s,
+      ...t,
+      city: s,
+      census_tract: r,
       state_fips: l,
-      county_fips: a,
-      tract_code: r,
+      county_fips: e,
+      tract_code: n,
     }
   );
 }
-let ne = null;
-async function En() {
-  if (ne) return ne;
+let Q = null;
+async function zt() {
+  if (Q) return Q;
   try {
-    const e = await ie(
+    const t = await tt(
         "https://api.census.gov/data/2022/acs/acs5/groups/C16001.json",
       ),
-      n = (e == null ? void 0 : e.variables) || {},
-      s = [],
-      i = {};
-    for (const [o, l] of Object.entries(n)) {
+      s = (t == null ? void 0 : t.variables) || {},
+      r = [],
+      a = {};
+    for (const [o, l] of Object.entries(s)) {
       if (!o.endsWith("E")) continue;
-      const a = l.label || "",
-        r = /^Estimate!!Total:!!([^:]+):$/.exec(a);
-      r && (s.push(o), (i[o] = r[1]));
+      const e = l.label || "",
+        n = /^Estimate!!Total:!!([^:]+):$/.exec(e);
+      n && (r.push(o), (a[o] = n[1]));
     }
-    ne = { codes: s, names: i };
+    Q = { codes: r, names: a };
   } catch {
-    ne = { codes: [], names: {} };
+    Q = { codes: [], names: {} };
   }
-  return ne;
+  return Q;
 }
-async function Le(e = []) {
-  var v, h;
-  const { codes: n, names: s } = await En();
-  if (!n.length) return {};
-  const i = {};
-  for (const m of e) {
-    const E = String(m)
+async function St(t = []) {
+  var y, v;
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (yt.has(s)) return { ...yt.get(s) };
+  const { codes: r, names: a } = await zt();
+  if (!r.length) return {};
+  const o = {};
+  for (const d of t) {
+    const c = String(d)
       .replace(/[^0-9]/g, "")
       .padStart(11, "0");
-    if (E.length !== 11) continue;
-    const _ = E.slice(0, 2),
-      u = E.slice(2, 5),
-      g = E.slice(5),
-      w = `${_}${u}`;
-    (i[w] || (i[w] = { state: _, county: u, tracts: [] }), i[w].tracts.push(g));
+    if (c.length !== 11) continue;
+    const g = c.slice(0, 2),
+      _ = c.slice(2, 5),
+      A = c.slice(5),
+      b = `${g}${_}`;
+    (o[b] || (o[b] = { state: g, county: _, tracts: [] }), o[b].tracts.push(A));
   }
-  let o = 0,
-    l = 0,
-    a = 0;
-  const r = {},
-    f = Object.values(i).map(async (m) => {
-      const E = oe(m.tracts, 50),
-        _ = await Promise.all(
-          E.map(async (g) => {
-            const w = g.join(","),
-              b = 40,
-              R = [];
-            for (let L = 0; L < n.length; L += b) {
-              const Y = n.slice(L, L + b),
-                z = `https://api.census.gov/data/2022/acs/acs5?get=${(L === 0 ? ["C16001_001E", "C16001_002E", ...Y] : Y).join(",")}&for=tract:${w}&in=state:${m.state}%20county:${m.county}`;
-              R.push(
-                fetch(z)
-                  .then((at) => at.json())
-                  .then((at) => ({ type: "lang", rows: at, chunk: Y }))
+  let l = 0,
+    e = 0,
+    n = 0;
+  const u = {},
+    p = Object.values(o).map(async (d) => {
+      const c = st(d.tracts, 50),
+        g = await Promise.all(
+          c.map(async (A) => {
+            const b = A.join(","),
+              C = 40,
+              $ = [];
+            for (let E = 0; E < r.length; E += C) {
+              const D = r.slice(E, E + C),
+                U = `https://api.census.gov/data/2022/acs/acs5?get=${(E === 0 ? ["C16001_001E", "C16001_002E", ...D] : D).join(",")}&for=tract:${b}&in=state:${d.state}%20county:${d.county}`;
+              $.push(
+                fetch(U)
+                  .then((G) => G.json())
+                  .then((G) => ({ type: "lang", rows: G, chunk: D }))
                   .catch(() => null),
               );
             }
-            const U = `https://api.census.gov/data/2022/acs/acs5/profile?get=DP02_0115E&for=tract:${w}&in=state:${m.state}%20county:${m.county}`;
-            R.push(
-              fetch(U)
-                .then((L) => L.json())
-                .then((L) => ({ type: "english", rows: L }))
+            const P = `https://api.census.gov/data/2022/acs/acs5/profile?get=DP02_0115E&for=tract:${b}&in=state:${d.state}%20county:${d.county}`;
+            $.push(
+              fetch(P)
+                .then((E) => E.json())
+                .then((E) => ({ type: "english", rows: E }))
                 .catch(() => null),
             );
-            const $ = await Promise.all(R);
-            let j = 0,
-              G = 0,
-              Z = 0;
-            const C = {};
-            for (const L of $) {
-              if (!L || !Array.isArray(L.rows) || L.rows.length <= 1) continue;
-              const { rows: Y } = L;
-              if (L.type === "lang") {
-                const ot = Y[0];
-                for (let z = 1; z < Y.length; z++) {
-                  const at = Y[z],
-                    rt = {};
-                  (ot.forEach((ct, lt) => (rt[ct] = Number(at[lt]))),
-                    (j += rt.C16001_001E || 0),
-                    (G += rt.C16001_002E || 0));
-                  for (const ct of L.chunk) {
-                    const lt = s[ct],
-                      Dt = rt[ct] || 0;
-                    lt && (C[lt] = (C[lt] || 0) + Dt);
+            const T = await Promise.all($);
+            let B = 0,
+              O = 0,
+              q = 0;
+            const X = {};
+            for (const E of T) {
+              if (!E || !Array.isArray(E.rows) || E.rows.length <= 1) continue;
+              const { rows: D } = E;
+              if (E.type === "lang") {
+                const V = D[0];
+                for (let U = 1; U < D.length; U++) {
+                  const G = D[U],
+                    j = {};
+                  (V.forEach((H, x) => (j[H] = Number(G[x]))),
+                    (B += j.C16001_001E || 0),
+                    (O += j.C16001_002E || 0));
+                  for (const H of E.chunk) {
+                    const x = a[H],
+                      ot = j[H] || 0;
+                    x && (X[x] = (X[x] || 0) + ot);
                   }
                 }
-              } else if (L.type === "english") {
-                const ot = Y[0];
-                for (let z = 1; z < Y.length; z++) {
-                  const at = Y[z],
-                    rt = {};
-                  (ot.forEach((ct, lt) => (rt[ct] = Number(at[lt]))),
-                    (Z += rt.DP02_0115E || 0));
+              } else if (E.type === "english") {
+                const V = D[0];
+                for (let U = 1; U < D.length; U++) {
+                  const G = D[U],
+                    j = {};
+                  (V.forEach((H, x) => (j[H] = Number(G[x]))),
+                    (q += j.DP02_0115E || 0));
                 }
               }
             }
-            return { total: j, englishOnly: G, englishLess: Z, langCounts: C };
+            return { total: B, englishOnly: O, englishLess: q, langCounts: X };
           }),
         ),
-        u = { total: 0, englishOnly: 0, englishLess: 0, langCounts: {} };
-      for (const g of _) {
-        ((u.total += g.total),
-          (u.englishOnly += g.englishOnly),
-          (u.englishLess += g.englishLess));
-        for (const [w, b] of Object.entries(g.langCounts))
-          u.langCounts[w] = (u.langCounts[w] || 0) + b;
+        _ = { total: 0, englishOnly: 0, englishLess: 0, langCounts: {} };
+      for (const A of g) {
+        ((_.total += A.total),
+          (_.englishOnly += A.englishOnly),
+          (_.englishLess += A.englishLess));
+        for (const [b, C] of Object.entries(A.langCounts))
+          _.langCounts[b] = (_.langCounts[b] || 0) + C;
       }
-      return u;
+      return _;
     }),
-    d = await Promise.all(f);
-  for (const m of d) {
-    ((o += m.total), (l += m.englishOnly), (a += m.englishLess));
-    for (const [E, _] of Object.entries(m.langCounts)) r[E] = (r[E] || 0) + _;
+    i = await Promise.all(p);
+  for (const d of i) {
+    ((l += d.total), (e += d.englishOnly), (n += d.englishLess));
+    for (const [c, g] of Object.entries(d.langCounts)) u[c] = (u[c] || 0) + g;
   }
-  r.English = l;
-  const c = r.Spanish || 0,
-    y = Object.entries(r).sort((m, E) => E[1] - m[1]);
-  return {
-    primary_language: (v = y[0]) == null ? void 0 : v[0],
-    secondary_language: (h = y[1]) == null ? void 0 : h[0],
-    language_other_than_english_pct: o ? ((o - l) / o) * 100 : null,
-    english_less_than_very_well_pct: o ? (a / o) * 100 : null,
-    spanish_at_home_pct: o ? (c / o) * 100 : null,
-  };
+  u.English = e;
+  const m = u.Spanish || 0,
+    f = Object.entries(u).sort((d, c) => c[1] - d[1]),
+    h = {
+      primary_language: (y = f[0]) == null ? void 0 : y[0],
+      secondary_language: (v = f[1]) == null ? void 0 : v[0],
+      language_other_than_english_pct: l ? ((l - e) / l) * 100 : null,
+      english_less_than_very_well_pct: l ? (n / l) * 100 : null,
+      spanish_at_home_pct: l ? (m / l) * 100 : null,
+    };
+  return (yt.set(s, h), { ...h });
 }
-async function es({ state_fips: e, county_fips: n, tract_code: s } = {}) {
-  if (!e || !n || !s) return {};
-  const i = `${e}${n}${s}`;
-  return Le([i]);
+async function $e({ state_fips: t, county_fips: s, tract_code: r } = {}) {
+  if (!t || !s || !r) return {};
+  const a = `${t}${s}${r}`;
+  return St([a]);
 }
-async function on(e = []) {
-  const n = {};
-  for (const f of e) {
-    const d = String(f)
+async function Bt(t = []) {
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (gt.has(s)) return { ...gt.get(s) };
+  const r = {};
+  for (const p of t) {
+    const i = String(p)
       .replace(/[^0-9]/g, "")
       .padStart(11, "0");
-    if (d.length !== 11) continue;
-    const c = d.slice(0, 2),
-      y = d.slice(2, 5),
-      v = d.slice(5),
-      h = `${c}${y}`;
-    (n[h] || (n[h] = { state: c, county: y, tracts: [] }), n[h].tracts.push(v));
+    if (i.length !== 11) continue;
+    const m = i.slice(0, 2),
+      f = i.slice(2, 5),
+      h = i.slice(5),
+      y = `${m}${f}`;
+    (r[y] || (r[y] = { state: m, county: f, tracts: [] }), r[y].tracts.push(h));
   }
-  let s = 0,
-    i = 0,
+  let a = 0,
     o = 0,
     l = 0,
-    a = 0;
-  for (const f of Object.values(n)) {
-    const d = oe(f.tracts, 50);
-    for (const c of d) {
-      const y =
+    e = 0,
+    n = 0;
+  for (const p of Object.values(r)) {
+    const i = st(p.tracts, 50);
+    for (const m of i) {
+      const f =
         "https://api.census.gov/data/2022/acs/acs5/profile?get=DP05_0001E,DP05_0018E,DP03_0062E,DP03_0088E,DP03_0128PE&for=tract:" +
-        c.join(",") +
-        `&in=state:${f.state}%20county:${f.county}`;
+        m.join(",") +
+        `&in=state:${p.state}%20county:${p.county}`;
       try {
-        const v = await fetch(y).then((h) => h.json());
-        if (!Array.isArray(v) || v.length < 2) continue;
-        for (let h = 1; h < v.length; h++) {
-          const [m, E, _, u, g] = v[h].map(Number);
-          Number.isFinite(m) &&
-            m > 0 &&
-            ((s += m),
-            Number.isFinite(E) && (i += E * m),
-            Number.isFinite(_) && (o += _ * m),
-            Number.isFinite(u) && (l += u * m),
-            Number.isFinite(g) && g >= 0 && (a += (g / 100) * m));
+        const h = await fetch(f).then((y) => y.json());
+        if (!Array.isArray(h) || h.length < 2) continue;
+        for (let y = 1; y < h.length; y++) {
+          const [v, d, c, g, _] = h[y].map(Number);
+          Number.isFinite(v) &&
+            v > 0 &&
+            ((a += v),
+            Number.isFinite(d) && (o += d * v),
+            Number.isFinite(c) && (l += c * v),
+            Number.isFinite(g) && (e += g * v),
+            Number.isFinite(_) && _ >= 0 && (n += (_ / 100) * v));
         }
       } catch {}
     }
   }
-  const r = {};
+  const u = {};
   return (
-    s > 0 &&
-      ((r.population = s),
-      i > 0 && (r.median_age = i / s),
-      o > 0 && (r.median_household_income = o / s),
-      l > 0 && (r.per_capita_income = l / s),
-      a > 0 && (r.poverty_rate = (a / s) * 100)),
-    r
+    a > 0 &&
+      ((u.population = a),
+      o > 0 && (u.median_age = o / a),
+      l > 0 && (u.median_household_income = l / a),
+      e > 0 && (u.per_capita_income = e / a),
+      n > 0 && (u.poverty_rate = (n / a) * 100)),
+    gt.set(s, u),
+    { ...u }
   );
 }
-async function an(e = []) {
-  const n = {};
-  for (const y of e) {
-    const v = String(y)
+async function Mt(t = []) {
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (ft.has(s)) return { ...ft.get(s) };
+  const r = {};
+  for (const f of t) {
+    const h = String(f)
       .replace(/[^0-9]/g, "")
       .padStart(11, "0");
-    if (v.length !== 11) continue;
-    const h = v.slice(0, 2),
-      m = v.slice(2, 5),
-      E = v.slice(5),
-      _ = `${h}${m}`;
-    (n[_] || (n[_] = { state: h, county: m, tracts: [] }), n[_].tracts.push(E));
+    if (h.length !== 11) continue;
+    const y = h.slice(0, 2),
+      v = h.slice(2, 5),
+      d = h.slice(5),
+      c = `${y}${v}`;
+    (r[c] || (r[c] = { state: y, county: v, tracts: [] }), r[c].tracts.push(d));
   }
-  let s = 0,
-    i = 0,
+  let a = 0,
     o = 0,
     l = 0,
-    a = 0,
-    r = 0,
-    f = 0;
-  for (const y of Object.values(n)) {
-    const v = oe(y.tracts, 50);
-    for (const h of v) {
-      const m =
+    e = 0,
+    n = 0,
+    u = 0,
+    p = 0;
+  for (const f of Object.values(r)) {
+    const h = st(f.tracts, 50);
+    for (const y of h) {
+      const v =
         "https://api.census.gov/data/2022/acs/acs5/profile?get=" +
         [
           "DP04_0045E",
@@ -1950,157 +443,164 @@ async function an(e = []) {
           "DP02_0068E",
         ].join(",") +
         "&for=tract:" +
-        h.join(",") +
-        `&in=state:${y.state}%20county:${y.county}`;
+        y.join(",") +
+        `&in=state:${f.state}%20county:${f.county}`;
       try {
-        const E = await fetch(m).then((_) => _.json());
-        if (!Array.isArray(E) || E.length < 2) continue;
-        for (let _ = 1; _ < E.length; _++) {
-          const [u, g, w, b, R, U, $] = E[_].slice(0, 7).map(Number);
-          (Number.isFinite(u) && u > 0 && (s += u),
-            Number.isFinite(g) &&
-              g > 0 &&
-              ((i += g), Number.isFinite(b) && b > 0 && (l += b * g)),
-            Number.isFinite(w) && w > 0 && (o += w),
-            Number.isFinite(R) &&
-              R > 0 &&
-              ((a += R),
-              Number.isFinite(U) && U > 0 && (r += U),
-              Number.isFinite($) && $ > 0 && (f += $)));
+        const d = await fetch(v).then((c) => c.json());
+        if (!Array.isArray(d) || d.length < 2) continue;
+        for (let c = 1; c < d.length; c++) {
+          const [g, _, A, b, C, $, P] = d[c].slice(0, 7).map(Number);
+          (Number.isFinite(g) && g > 0 && (a += g),
+            Number.isFinite(_) &&
+              _ > 0 &&
+              ((o += _), Number.isFinite(b) && b > 0 && (e += b * _)),
+            Number.isFinite(A) && A > 0 && (l += A),
+            Number.isFinite(C) &&
+              C > 0 &&
+              ((n += C),
+              Number.isFinite($) && $ > 0 && (u += $),
+              Number.isFinite(P) && P > 0 && (p += P)));
         }
       } catch {}
     }
   }
-  const d = {},
-    c = i + o;
+  const i = {},
+    m = o + l;
   return (
-    c > 0 &&
-      ((d.owner_occupied_pct = (i / c) * 100),
-      (d.renter_occupied_pct = (o / c) * 100)),
-    i > 0 && l > 0 && (d.median_home_value = l / i),
-    a > 0 &&
-      ((d.high_school_or_higher_pct = (r / a) * 100),
-      (d.bachelors_or_higher_pct = (f / a) * 100)),
-    d
+    m > 0 &&
+      ((i.owner_occupied_pct = (o / m) * 100),
+      (i.renter_occupied_pct = (l / m) * 100)),
+    o > 0 && e > 0 && (i.median_home_value = e / o),
+    n > 0 &&
+      ((i.high_school_or_higher_pct = (u / n) * 100),
+      (i.bachelors_or_higher_pct = (p / n) * 100)),
+    ft.set(s, i),
+    { ...i }
   );
 }
-async function ns(e = []) {
-  const n = {};
-  for (const i of e) {
-    const o = String(i)
+async function Ee(t = []) {
+  const s = {};
+  for (const a of t) {
+    const o = String(a)
       .replace(/[^0-9]/g, "")
       .padStart(11, "0");
     if (o.length !== 11) continue;
     const l = o.slice(0, 2),
-      a = o.slice(2, 5),
-      r = o.slice(5),
-      f = `${l}${a}`;
-    (n[f] || (n[f] = { state: l, county: a, tracts: [] }), n[f].tracts.push(r));
+      e = o.slice(2, 5),
+      n = o.slice(5),
+      u = `${l}${e}`;
+    (s[u] || (s[u] = { state: l, county: e, tracts: [] }), s[u].tracts.push(n));
   }
-  const s = {};
-  for (const i of Object.values(n)) {
-    const o = oe(i.tracts, 50);
+  const r = {};
+  for (const a of Object.values(s)) {
+    const o = st(a.tracts, 50);
     for (const l of o) {
-      const a =
+      const e =
         "https://api.census.gov/data/2022/acs/acs5/profile?get=DP05_0001E,DP05_0018E,DP03_0062E,DP03_0088E,DP03_0128PE,DP03_0009PE&for=tract:" +
         l.join(",") +
-        `&in=state:${i.state}%20county:${i.county}`;
+        `&in=state:${a.state}%20county:${a.county}`;
       try {
-        const r = await fetch(a).then((f) => f.json());
-        if (!Array.isArray(r) || r.length < 2) continue;
-        for (let f = 1; f < r.length; f++) {
-          const [d, c, y, v, h, m, E, _, u] = r[f],
-            g = `${E}${_}${u}`;
-          s[g] = {
-            population: Number(d),
-            median_age: Number(c),
-            median_household_income: Number(y),
-            per_capita_income: Number(v),
+        const n = await fetch(e).then((u) => u.json());
+        if (!Array.isArray(n) || n.length < 2) continue;
+        for (let u = 1; u < n.length; u++) {
+          const [p, i, m, f, h, y, v, d, c] = n[u],
+            g = `${v}${d}${c}`;
+          r[g] = {
+            population: Number(p),
+            median_age: Number(i),
+            median_household_income: Number(m),
+            per_capita_income: Number(f),
             poverty_rate: Number(h),
-            unemployment_rate: Number(m),
+            unemployment_rate: Number(y),
           };
         }
       } catch {}
     }
   }
-  return s;
+  return r;
 }
-async function Ie(e = []) {
-  const n = {};
-  for (const i of e) {
-    const o = String(i)
+async function kt(t = []) {
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (vt.has(s)) return { ...vt.get(s) };
+  const r = {};
+  for (const o of t) {
+    const l = String(o)
       .replace(/[^0-9]/g, "")
       .padStart(11, "0");
-    if (o.length !== 11) continue;
-    const l = o.slice(0, 2),
-      a = o.slice(2, 5),
-      r = o.slice(5),
-      f = `${l}${a}`;
-    (n[f] || (n[f] = { state: l, county: a, tracts: [] }), n[f].tracts.push(r));
+    if (l.length !== 11) continue;
+    const e = l.slice(0, 2),
+      n = l.slice(2, 5),
+      u = l.slice(5),
+      p = `${e}${n}`;
+    (r[p] || (r[p] = { state: e, county: n, tracts: [] }), r[p].tracts.push(u));
   }
-  const s = {};
-  for (const i of Object.values(n)) {
-    const o = oe(i.tracts, 50);
-    for (const l of o) {
-      const a =
+  const a = {};
+  for (const o of Object.values(r)) {
+    const l = st(o.tracts, 50);
+    for (const e of l) {
+      const n =
         "https://api.census.gov/data/2022/acs/acs5/profile?get=DP03_0009PE,DP05_0001E&for=tract:" +
-        l.join(",") +
-        `&in=state:${i.state}%20county:${i.county}`;
+        e.join(",") +
+        `&in=state:${o.state}%20county:${o.county}`;
       try {
-        const r = await fetch(a).then((f) => f.json());
-        if (!Array.isArray(r) || r.length < 2) continue;
-        for (let f = 1; f < r.length; f++) {
-          const [d, c, y, v, h] = r[f],
-            m = `${y}${v}${h}`;
-          s[m] = { unemployment_rate: Number(d), population: Number(c) };
+        const u = await fetch(n).then((p) => p.json());
+        if (!Array.isArray(u) || u.length < 2) continue;
+        for (let p = 1; p < u.length; p++) {
+          const [i, m, f, h, y] = u[p],
+            v = `${f}${h}${y}`;
+          a[v] = { unemployment_rate: Number(i), population: Number(m) };
         }
       } catch {}
     }
   }
-  return s;
+  return (vt.set(s, a), { ...a });
 }
-async function wn(e = []) {
-  const n =
+async function qt(t = []) {
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (wt.has(s)) return [...wt.get(s)];
+  const r =
       "https://gis.water.ca.gov/arcgis/rest/services/Society/i16_Census_Tract_DisadvantagedCommunities_2020/MapServer/0/query",
-    s = new Set(),
-    i = 50;
-  for (let o = 0; o < e.length; o += i) {
-    const l = e.slice(o, o + i);
-    if (!l.length) continue;
-    const a = `GEOID20 IN (${l.map((f) => `'${f}'`).join(",")})`,
-      r =
-        n +
-        `?where=${encodeURIComponent(a)}&outFields=GEOID20,DAC20&returnGeometry=false&f=json`;
+    a = new Set(),
+    o = 50;
+  for (let e = 0; e < t.length; e += o) {
+    const n = t.slice(e, e + o);
+    if (!n.length) continue;
+    const u = `GEOID20 IN (${n.map((i) => `'${i}'`).join(",")})`,
+      p =
+        r +
+        `?where=${encodeURIComponent(u)}&outFields=GEOID20,DAC20&returnGeometry=false&f=json`;
     try {
-      const f = await fetch(r).then((d) => d.json());
-      for (const d of f.features || []) {
-        const c = d.attributes || {},
-          y = String(c.GEOID20);
-        String(c.DAC20 || "").toUpperCase() === "Y" && s.add(y);
+      const i = await fetch(p).then((m) => m.json());
+      for (const m of i.features || []) {
+        const f = m.attributes || {},
+          h = String(f.GEOID20);
+        String(f.DAC20 || "").toUpperCase() === "Y" && a.add(h);
       }
     } catch {}
   }
-  return Array.from(s);
+  const l = Array.from(a);
+  return (wt.set(s, l), [...l]);
 }
-async function rn(e = []) {
-  const n = new Set();
-  return (
-    await Promise.all(
-      e.map(async (s) => {
-        try {
-          const i = he("/lookup", { fips: s, census_tract: s, geoid: s }),
-            o = await ie(i);
-          Array.isArray(o.environmental_hardships) &&
-            o.environmental_hardships.forEach((l) => n.add(l));
-        } catch {}
-      }),
-    ),
-    Array.from(n).sort()
+async function Ot(t = []) {
+  const s = [...new Set(t.map(String))].sort().join(",");
+  if (At.has(s)) return [...At.get(s)];
+  const r = new Set();
+  await Promise.all(
+    t.map(async (o) => {
+      try {
+        const l = at("/lookup", { fips: o, census_tract: o, geoid: o }),
+          e = await tt(l);
+        Array.isArray(e.environmental_hardships) &&
+          e.environmental_hardships.forEach((n) => r.add(n));
+      } catch {}
+    }),
   );
+  const a = Array.from(r).sort();
+  return (At.set(s, a), [...a]);
 }
-async function ss(e = {}) {
-  const { state_fips: n, county_fips: s, tract_code: i } = e || {},
-    o = n && s && i ? `${n}${s}${i}` : null;
+async function ke(t = {}) {
+  const { state_fips: s, county_fips: r, tract_code: a } = t || {},
+    o = s && r && a ? `${s}${r}${a}` : null;
   if (
     !(
       o &&
@@ -2111,189 +611,189 @@ async function ss(e = {}) {
         "per_capita_income",
         "poverty_rate",
         "unemployment_rate",
-      ].some((c) => Q(e[c]))
+      ].some((i) => R(t[i]))
     )
   )
-    return e;
-  const f = (await ns([o]))[o];
-  if (!f) return e;
-  const d = { ...e };
-  d.demographics = { ...d.demographics, ...f };
-  for (const [c, y] of Object.entries(f)) Q(d[c]) && (d[c] = y);
-  return d;
+    return t;
+  const u = (await Ee([o]))[o];
+  if (!u) return t;
+  const p = { ...t };
+  p.demographics = { ...p.demographics, ...u };
+  for (const [i, m] of Object.entries(u)) R(p[i]) && (p[i] = m);
+  return p;
 }
-async function is(e = {}) {
-  var r, f;
-  const { surrounding_10_mile: n, water_district: s } = e || {},
-    i = { ...e },
-    o = n || {};
+async function Ce(t = {}) {
+  var n, u;
+  const { surrounding_10_mile: s, water_district: r } = t || {},
+    a = { ...t },
+    o = s || {};
   if (Array.isArray(o.census_tracts_fips) && o.census_tracts_fips.length) {
-    const d = await on(o.census_tracts_fips),
-      c = o.demographics || {};
-    i.surrounding_10_mile = { ...o, demographics: { ...c, ...d } };
+    const p = await Bt(o.census_tracts_fips),
+      i = o.demographics || {};
+    a.surrounding_10_mile = { ...o, demographics: { ...i, ...p } };
   }
-  const l = s || {},
-    a = Array.isArray(l.census_tracts_fips)
+  const l = r || {},
+    e = Array.isArray(l.census_tracts_fips)
       ? l.census_tracts_fips.map(String)
       : [];
-  if (a.length) {
-    const d = await on(a),
-      c = l.demographics || {},
-      y =
-        (f = (r = i.surrounding_10_mile) == null ? void 0 : r.demographics) ==
+  if (e.length) {
+    const p = await Bt(e),
+      i = l.demographics || {},
+      m =
+        (u = (n = a.surrounding_10_mile) == null ? void 0 : n.demographics) ==
         null
           ? void 0
-          : f.median_household_income,
-      v = { ...c, ...d };
-    (y != null &&
-      (!Number.isFinite(v.median_household_income) ||
-        v.median_household_income < 0) &&
-      (v.median_household_income = y),
-      (i.water_district = { ...l, demographics: v }));
+          : u.median_household_income,
+      f = { ...i, ...p };
+    (m != null &&
+      (!Number.isFinite(f.median_household_income) ||
+        f.median_household_income < 0) &&
+      (f.median_household_income = m),
+      (a.water_district = { ...l, demographics: f }));
   }
-  return i;
+  return a;
 }
-async function os(e = {}) {
-  var r, f;
-  const { surrounding_10_mile: n, water_district: s } = e || {},
-    i = { ...e },
-    o = n || {};
+async function Ne(t = {}) {
+  var n, u;
+  const { surrounding_10_mile: s, water_district: r } = t || {},
+    a = { ...t },
+    o = s || {};
   if (Array.isArray(o.census_tracts_fips) && o.census_tracts_fips.length) {
-    const d = o.demographics || {};
+    const p = o.demographics || {};
     if (
       [
-        d.owner_occupied_pct,
-        d.renter_occupied_pct,
-        d.median_home_value,
-        d.high_school_or_higher_pct,
-        d.bachelors_or_higher_pct,
-      ].some((y) => Q(y) || (typeof y == "number" && y < 0))
+        p.owner_occupied_pct,
+        p.renter_occupied_pct,
+        p.median_home_value,
+        p.high_school_or_higher_pct,
+        p.bachelors_or_higher_pct,
+      ].some((m) => R(m) || (typeof m == "number" && m < 0))
     ) {
-      const y = await an(o.census_tracts_fips);
-      i.surrounding_10_mile = { ...o, demographics: { ...d, ...y } };
+      const m = await Mt(o.census_tracts_fips);
+      a.surrounding_10_mile = { ...o, demographics: { ...p, ...m } };
     }
   }
-  const l = s || {},
-    a = Array.isArray(l.census_tracts_fips)
+  const l = r || {},
+    e = Array.isArray(l.census_tracts_fips)
       ? l.census_tracts_fips.map(String)
       : [];
-  if (a.length) {
-    const d = l.demographics || {};
+  if (e.length) {
+    const p = l.demographics || {};
     if (
       [
-        d.owner_occupied_pct,
-        d.renter_occupied_pct,
-        d.median_home_value,
-        d.high_school_or_higher_pct,
-        d.bachelors_or_higher_pct,
-      ].some((y) => Q(y) || (typeof y == "number" && y < 0))
+        p.owner_occupied_pct,
+        p.renter_occupied_pct,
+        p.median_home_value,
+        p.high_school_or_higher_pct,
+        p.bachelors_or_higher_pct,
+      ].some((m) => R(m) || (typeof m == "number" && m < 0))
     ) {
-      const y = await an(a);
-      let v = { ...d, ...y };
+      const m = await Mt(e);
+      let f = { ...p, ...m };
       const h =
-        (f = (r = i.surrounding_10_mile) == null ? void 0 : r.demographics) ==
+        (u = (n = a.surrounding_10_mile) == null ? void 0 : n.demographics) ==
         null
           ? void 0
-          : f.median_home_value;
+          : u.median_home_value;
       (h != null &&
-        (!Number.isFinite(v.median_home_value) || v.median_home_value < 0) &&
-        (v.median_home_value = h),
-        (i.water_district = { ...l, demographics: v }));
+        (!Number.isFinite(f.median_home_value) || f.median_home_value < 0) &&
+        (f.median_home_value = h),
+        (a.water_district = { ...l, demographics: f }));
     }
   }
-  return i;
+  return a;
 }
-async function as(e = {}) {
+async function Pe(t = {}) {
   const {
-      state_fips: n,
-      county_fips: s,
-      tract_code: i,
+      state_fips: s,
+      county_fips: r,
+      tract_code: a,
       unemployment_rate: o,
       surrounding_10_mile: l,
-      water_district: a,
-    } = e || {},
-    r = l || {},
-    f = a || {},
-    d = [],
-    c = n && s && i ? `${n}${s}${i}` : null;
-  Q(o) && c && d.push(c);
-  const y = Array.isArray(r.census_tracts_fips) ? r.census_tracts_fips : [];
-  r.demographics &&
-    Q(r.demographics.unemployment_rate) &&
-    y.length &&
-    d.push(...y);
-  const v = Array.isArray(f.census_tracts_fips)
-    ? f.census_tracts_fips.map(String)
+      water_district: e,
+    } = t || {},
+    n = l || {},
+    u = e || {},
+    p = [],
+    i = s && r && a ? `${s}${r}${a}` : null;
+  R(o) && i && p.push(i);
+  const m = Array.isArray(n.census_tracts_fips) ? n.census_tracts_fips : [];
+  n.demographics &&
+    R(n.demographics.unemployment_rate) &&
+    m.length &&
+    p.push(...m);
+  const f = Array.isArray(u.census_tracts_fips)
+    ? u.census_tracts_fips.map(String)
     : [];
-  f.demographics &&
-    Q(f.demographics.unemployment_rate) &&
-    v.length &&
-    d.push(...v);
-  const h = Array.from(new Set(d));
-  if (!h.length) return e;
-  const m = await Ie(h),
-    E = { ...e };
+  u.demographics &&
+    R(u.demographics.unemployment_rate) &&
+    f.length &&
+    p.push(...f);
+  const h = Array.from(new Set(p));
+  if (!h.length) return t;
+  const y = await kt(h),
+    v = { ...t };
   if (
-    (Q(o) && c && m[c] && (E.unemployment_rate = m[c].unemployment_rate),
-    r.demographics && Q(r.demographics.unemployment_rate) && y.length)
+    (R(o) && i && y[i] && (v.unemployment_rate = y[i].unemployment_rate),
+    n.demographics && R(n.demographics.unemployment_rate) && m.length)
   ) {
-    let _ = 0,
-      u = 0;
-    for (const g of y) {
-      const w = m[g];
-      w &&
-        Number.isFinite(w.unemployment_rate) &&
-        Number.isFinite(w.population) &&
-        ((_ += w.population), (u += w.unemployment_rate * w.population));
+    let d = 0,
+      c = 0;
+    for (const g of m) {
+      const _ = y[g];
+      _ &&
+        Number.isFinite(_.unemployment_rate) &&
+        Number.isFinite(_.population) &&
+        ((d += _.population), (c += _.unemployment_rate * _.population));
     }
-    _ > 0 &&
-      (E.surrounding_10_mile = {
-        ...r,
-        demographics: { ...r.demographics, unemployment_rate: u / _ },
+    d > 0 &&
+      (v.surrounding_10_mile = {
+        ...n,
+        demographics: { ...n.demographics, unemployment_rate: c / d },
       });
   }
-  if (f.demographics && Q(f.demographics.unemployment_rate) && v.length) {
-    let _ = 0,
-      u = 0;
-    for (const g of v) {
-      const w = m[g];
-      w &&
-        Number.isFinite(w.unemployment_rate) &&
-        Number.isFinite(w.population) &&
-        ((_ += w.population), (u += w.unemployment_rate * w.population));
+  if (u.demographics && R(u.demographics.unemployment_rate) && f.length) {
+    let d = 0,
+      c = 0;
+    for (const g of f) {
+      const _ = y[g];
+      _ &&
+        Number.isFinite(_.unemployment_rate) &&
+        Number.isFinite(_.population) &&
+        ((d += _.population), (c += _.unemployment_rate * _.population));
     }
-    _ > 0 &&
-      (E.water_district = {
-        ...f,
-        demographics: { ...f.demographics, unemployment_rate: u / _ },
+    d > 0 &&
+      (v.water_district = {
+        ...u,
+        demographics: { ...u.demographics, unemployment_rate: c / d },
       });
   }
-  return E;
+  return v;
 }
-async function rs(e = {}) {
-  const { surrounding_10_mile: n, water_district: s } = e || {},
-    i = { ...e },
-    o = n || {};
+async function De(t = {}) {
+  const { surrounding_10_mile: s, water_district: r } = t || {},
+    a = { ...t },
+    o = s || {};
   if (Array.isArray(o.census_tracts_fips) && o.census_tracts_fips.length) {
-    const r = await Le(o.census_tracts_fips),
-      f = o.demographics || {};
-    i.surrounding_10_mile = { ...o, demographics: { ...f, ...r } };
+    const n = await St(o.census_tracts_fips),
+      u = o.demographics || {};
+    a.surrounding_10_mile = { ...o, demographics: { ...u, ...n } };
   }
-  const l = s || {},
-    a = Array.isArray(l.census_tracts_fips)
+  const l = r || {},
+    e = Array.isArray(l.census_tracts_fips)
       ? l.census_tracts_fips.map(String)
       : [];
-  if (a.length) {
-    const r = await Le(a),
-      f = l.demographics || {};
-    i.water_district = { ...l, demographics: { ...f, ...r } };
+  if (e.length) {
+    const n = await St(e),
+      u = l.demographics || {};
+    a.water_district = { ...l, demographics: { ...u, ...n } };
   }
-  return i;
+  return a;
 }
-async function cs(e = {}) {
-  const { surrounding_10_mile: n, water_district: s } = e || {},
-    i = { ...e },
-    o = n || {},
+async function Fe(t = {}) {
+  const { surrounding_10_mile: s, water_district: r } = t || {},
+    a = { ...t },
+    o = s || {},
     l =
       Array.isArray(o.census_tracts_fips) && o.census_tracts_fips.length
         ? o.census_tracts_fips
@@ -2305,224 +805,224 @@ async function cs(e = {}) {
       !o.environmental_hardships.length) &&
     l.length
   ) {
-    const f = await rn(l);
-    i.surrounding_10_mile = { ...o, environmental_hardships: f };
+    const u = await Ot(l);
+    a.surrounding_10_mile = { ...o, environmental_hardships: u };
   }
-  const a = s || {},
-    r = Array.isArray(a.census_tracts_fips)
-      ? a.census_tracts_fips.map(String)
+  const e = r || {},
+    n = Array.isArray(e.census_tracts_fips)
+      ? e.census_tracts_fips.map(String)
       : [];
   if (
-    (!Array.isArray(a.environmental_hardships) ||
-      !a.environmental_hardships.length) &&
-    r.length
+    (!Array.isArray(e.environmental_hardships) ||
+      !e.environmental_hardships.length) &&
+    n.length
   ) {
-    const f = await rn(r);
-    i.water_district = { ...a, environmental_hardships: f };
+    const u = await Ot(n);
+    a.water_district = { ...e, environmental_hardships: u };
   }
-  return i;
+  return a;
 }
-async function ls(e = {}) {
-  const { lat: n, lon: s, census_tract: i, surrounding_10_mile: o } = e || {};
-  if (n == null || s == null) return e;
+async function Te(t = {}) {
+  const { lat: s, lon: r, census_tract: a, surrounding_10_mile: o } = t || {};
+  if (s == null || r == null) return t;
   const l = 1609.34 * 10,
-    a = { ...(o || {}) },
-    r = [];
-  if (!Array.isArray(a.cities) || !a.cities.length) {
-    const h = `[out:json];(node[place=city](around:${l},${n},${s});node[place=town](around:${l},${n},${s}););out;`,
-      m =
+    e = { ...(o || {}) },
+    n = [];
+  if (!Array.isArray(e.cities) || !e.cities.length) {
+    const h = `[out:json];(node[place=city](around:${l},${s},${r});node[place=town](around:${l},${s},${r}););out;`,
+      y =
         "https://overpass-api.de/api/interpreter?data=" + encodeURIComponent(h);
-    r.push(
-      fetch(m)
-        .then((E) => E.json())
-        .then((E) => {
-          const _ = (E.elements || [])
-            .map((u) => {
+    n.push(
+      fetch(y)
+        .then((v) => v.json())
+        .then((v) => {
+          const d = (v.elements || [])
+            .map((c) => {
               var g;
-              return (g = u.tags) == null ? void 0 : g.name;
+              return (g = c.tags) == null ? void 0 : g.name;
             })
             .filter(Boolean);
-          a.cities = Array.from(new Set(_)).slice(0, 10);
+          e.cities = Array.from(new Set(d)).slice(0, 10);
         })
         .catch(() => {}),
     );
   }
-  const f = Array.isArray(a.census_tracts) ? a.census_tracts.map(String) : [],
-    d = Array.isArray(a.census_tracts_fips)
-      ? a.census_tracts_fips.map(String)
+  const u = Array.isArray(e.census_tracts) ? e.census_tracts.map(String) : [],
+    p = Array.isArray(e.census_tracts_fips)
+      ? e.census_tracts_fips.map(String)
       : [],
-    c = { ...(a.census_tract_map || {}) },
-    y = `https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer/10/query?where=1=1&geometry=${s},${n}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&distance=${l}&units=esriSRUnit_Meter&outFields=NAME,GEOID&f=json`;
-  (r.push(
-    fetch(y)
+    i = { ...(e.census_tract_map || {}) },
+    m = `https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer/10/query?where=1=1&geometry=${r},${s}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&distance=${l}&units=esriSRUnit_Meter&outFields=NAME,GEOID&f=json`;
+  (n.push(
+    fetch(m)
       .then((h) => h.json())
       .then((h) => {
-        const m = h.features || [],
-          E = [],
-          _ = [],
-          u = {};
-        for (const g of m) {
-          const w = g.attributes || {};
-          let b = null;
+        const y = h.features || [],
+          v = [],
+          d = [],
+          c = {};
+        for (const g of y) {
+          const _ = g.attributes || {};
+          let A = null;
           if (
-            (w.NAME &&
-              ((b = w.NAME.replace(/^Census Tract\s+/i, "")), E.push(b)),
-            w.GEOID)
+            (_.NAME &&
+              ((A = _.NAME.replace(/^Census Tract\s+/i, "")), v.push(A)),
+            _.GEOID)
           ) {
-            const R = String(w.GEOID);
-            (_.push(R), b && (u[R] = b));
+            const b = String(_.GEOID);
+            (d.push(b), A && (c[b] = A));
           }
         }
-        ((a.census_tracts = Array.from(new Set([...f, ...E]))),
-          (a.census_tracts_fips = Array.from(new Set([...d, ..._]))),
-          (a.census_tract_map = { ...c, ...u }));
+        ((e.census_tracts = Array.from(new Set([...u, ...v]))),
+          (e.census_tracts_fips = Array.from(new Set([...p, ...d]))),
+          (e.census_tract_map = { ...i, ...c }));
       })
       .catch(() => {}),
   ),
-    r.length && (await Promise.all(r)),
-    Array.isArray(a.cities) || (a.cities = []));
-  const v = new Set(Array.isArray(a.census_tracts) ? a.census_tracts : []);
+    n.length && (await Promise.all(n)),
+    Array.isArray(e.cities) || (e.cities = []));
+  const f = new Set(Array.isArray(e.census_tracts) ? e.census_tracts : []);
   if (
-    (i && v.add(String(i)),
-    (a.census_tracts = Array.from(v)),
-    Array.isArray(a.census_tracts_fips))
+    (a && f.add(String(a)),
+    (e.census_tracts = Array.from(f)),
+    Array.isArray(e.census_tracts_fips))
   ) {
-    const h = new Set(a.census_tracts_fips),
-      { state_fips: m, county_fips: E, tract_code: _ } = e || {};
-    (m && E && _ && h.add(`${m}${E}${_}`),
-      (a.census_tracts_fips = Array.from(h)));
+    const h = new Set(e.census_tracts_fips),
+      { state_fips: y, county_fips: v, tract_code: d } = t || {};
+    (y && v && d && h.add(`${y}${v}${d}`),
+      (e.census_tracts_fips = Array.from(h)));
   }
-  if (Array.isArray(a.census_tracts_fips) && a.census_tracts_fips.length)
+  if (Array.isArray(e.census_tracts_fips) && e.census_tracts_fips.length)
     try {
-      const h = await wn(a.census_tracts_fips),
-        m = [];
-      for (const E of h) {
-        const _ = (a.census_tract_map && a.census_tract_map[E]) || E;
-        m.push(_);
+      const h = await qt(e.census_tracts_fips),
+        y = [];
+      for (const v of h) {
+        const d = (e.census_tract_map && e.census_tract_map[v]) || v;
+        y.push(d);
       }
-      if (((a.dac_tracts = m), (a.dac_tracts_fips = h), m.length)) {
-        const E = new Set([...(a.census_tracts || []), ...m]);
-        a.census_tracts = Array.from(E);
+      if (((e.dac_tracts = y), (e.dac_tracts_fips = h), y.length)) {
+        const v = new Set([...(e.census_tracts || []), ...y]);
+        e.census_tracts = Array.from(v);
       }
     } catch {}
-  if (Array.isArray(a.census_tracts_fips) && a.census_tracts_fips.length)
+  if (Array.isArray(e.census_tracts_fips) && e.census_tracts_fips.length)
     try {
-      const h = await Ie(a.census_tracts_fips);
-      let m = 0,
-        E = 0;
-      const _ = new Set(a.dac_tracts_fips || []);
-      for (const u of a.census_tracts_fips) {
-        const g = h[u];
+      const h = await kt(e.census_tracts_fips);
+      let y = 0,
+        v = 0;
+      const d = new Set(e.dac_tracts_fips || []);
+      for (const c of e.census_tracts_fips) {
+        const g = h[c];
         g &&
           Number.isFinite(g.population) &&
-          ((m += g.population), _.has(String(u)) && (E += g.population));
+          ((y += g.population), d.has(String(c)) && (v += g.population));
       }
-      (m > 0 && (a.dac_population_pct = (E / m) * 100),
-        a.census_tracts_fips.length > 0 &&
-          (a.dac_tracts_pct = (_.size / a.census_tracts_fips.length) * 100));
+      (y > 0 && (e.dac_population_pct = (v / y) * 100),
+        e.census_tracts_fips.length > 0 &&
+          (e.dac_tracts_pct = (d.size / e.census_tracts_fips.length) * 100));
     } catch {}
-  return { ...e, surrounding_10_mile: a };
+  return { ...t, surrounding_10_mile: e };
 }
-async function us(e = {}, n = "") {
-  var m, E;
+async function Re(t = {}, s = "") {
+  var y, v;
   const {
-    lat: s,
-    lon: i,
+    lat: r,
+    lon: a,
     city: o,
     census_tract: l,
-    state_fips: a,
-    county_fips: r,
-    tract_code: f,
-    water_district: d,
-  } = e || {};
-  if (s == null || i == null) return e;
-  const c = { ...d },
-    y = [];
-  if (n) {
-    const _ = he("/lookup", { address: n });
-    y.push(
-      ie(_)
-        .then((u) => {
-          var w, b, R, U;
-          c.name =
-            ((w = u == null ? void 0 : u.agency) == null
+    state_fips: e,
+    county_fips: n,
+    tract_code: u,
+    water_district: p,
+  } = t || {};
+  if (r == null || a == null) return t;
+  const i = { ...p },
+    m = [];
+  if (s) {
+    const d = at("/lookup", { address: s });
+    m.push(
+      tt(d)
+        .then((c) => {
+          var _, A, b, C;
+          i.name =
+            ((_ = c == null ? void 0 : c.agency) == null
               ? void 0
-              : w.agency_name) ||
-            ((b = u == null ? void 0 : u.agency) == null ? void 0 : b.name) ||
-            (u == null ? void 0 : u.agency_name) ||
-            (u == null ? void 0 : u.name) ||
-            c.name;
+              : _.agency_name) ||
+            ((A = c == null ? void 0 : c.agency) == null ? void 0 : A.name) ||
+            (c == null ? void 0 : c.agency_name) ||
+            (c == null ? void 0 : c.name) ||
+            i.name;
           const g =
-            ((R = u == null ? void 0 : u.agency) == null
+            ((b = c == null ? void 0 : c.agency) == null
               ? void 0
-              : R.service_area_tracts) ||
-            (u == null ? void 0 : u.service_area_tracts) ||
-            (u == null ? void 0 : u.census_tracts) ||
-            ((U = u == null ? void 0 : u.agency) == null
+              : b.service_area_tracts) ||
+            (c == null ? void 0 : c.service_area_tracts) ||
+            (c == null ? void 0 : c.census_tracts) ||
+            ((C = c == null ? void 0 : c.agency) == null
               ? void 0
-              : U.census_tracts);
+              : C.census_tracts);
           if (typeof g == "string") {
             const $ = g.split(/\s*,\s*/).filter(Boolean);
-            c.census_tracts = $;
-            const j = $.filter((G) => /^\d{11}$/.test(G));
-            j.length && (c.census_tracts_fips = j);
+            i.census_tracts = $;
+            const P = $.filter((T) => /^\d{11}$/.test(T));
+            P.length && (i.census_tracts_fips = P);
           } else if (Array.isArray(g)) {
             const $ = [...new Set(g.map(String))];
-            c.census_tracts = $;
-            const j = $.filter((G) => /^\d{11}$/.test(G));
-            j.length &&
-              (c.census_tracts_fips = [
-                ...new Set([...(c.census_tracts_fips || []), ...j]),
+            i.census_tracts = $;
+            const P = $.filter((T) => /^\d{11}$/.test(T));
+            P.length &&
+              (i.census_tracts_fips = [
+                ...new Set([...(i.census_tracts_fips || []), ...P]),
               ]);
           }
         })
         .catch(() => {}),
     );
   }
-  if (!c.name) {
-    const _ = `https://services.arcgis.com/8DFNJhY7CUN8E0bX/ArcGIS/rest/services/Public_Water_System_Boundaries/FeatureServer/0/query?geometry=${i}%2C${s}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=PWS_NAME&returnGeometry=false&f=json`;
-    y.push(
-      fetch(_)
-        .then((u) => u.json())
-        .then((u) => {
-          var g, w, b;
-          c.name =
-            ((b =
-              (w =
-                (g = u == null ? void 0 : u.features) == null
+  if (!i.name) {
+    const d = `https://services.arcgis.com/8DFNJhY7CUN8E0bX/ArcGIS/rest/services/Public_Water_System_Boundaries/FeatureServer/0/query?geometry=${a}%2C${r}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=PWS_NAME&returnGeometry=false&f=json`;
+    m.push(
+      fetch(d)
+        .then((c) => c.json())
+        .then((c) => {
+          var g, _, A;
+          i.name =
+            ((A =
+              (_ =
+                (g = c == null ? void 0 : c.features) == null
                   ? void 0
                   : g[0]) == null
                 ? void 0
-                : w.attributes) == null
+                : _.attributes) == null
               ? void 0
-              : b.PWS_NAME) || c.name;
+              : A.PWS_NAME) || i.name;
         })
         .catch(() => {}),
     );
   }
   if (
-    ((!Array.isArray(c.cities) || !c.cities.length) && o && (c.cities = [o]),
-    y.length && (await Promise.all(y)),
-    c.name && (!Array.isArray(c.census_tracts) || !c.census_tracts.length))
+    ((!Array.isArray(i.cities) || !i.cities.length) && o && (i.cities = [o]),
+    m.length && (await Promise.all(m)),
+    i.name && (!Array.isArray(i.census_tracts) || !i.census_tracts.length))
   )
     try {
-      const _ = he("/census-tracts", { agency_name: c.name }),
-        u = await ie(_),
-        g = u == null ? void 0 : u.census_tracts;
-      Array.isArray(g) && (c.census_tracts = [...new Set(g.map(String))]);
+      const d = at("/census-tracts", { agency_name: i.name }),
+        c = await tt(d),
+        g = c == null ? void 0 : c.census_tracts;
+      Array.isArray(g) && (i.census_tracts = [...new Set(g.map(String))]);
     } catch {}
   try {
-    const _ = `https://services.arcgis.com/8DFNJhY7CUN8E0bX/ArcGIS/rest/services/Public_Water_System_Boundaries/FeatureServer/0/query?geometry=${i}%2C${s}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=PWS_NAME&returnGeometry=true&outSR=4326&f=json`,
-      u = await fetch(_).then((w) => w.json()),
+    const d = `https://services.arcgis.com/8DFNJhY7CUN8E0bX/ArcGIS/rest/services/Public_Water_System_Boundaries/FeatureServer/0/query?geometry=${a}%2C${r}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=PWS_NAME&returnGeometry=true&outSR=4326&f=json`,
+      c = await fetch(d).then((_) => _.json()),
       g =
-        (E = (m = u == null ? void 0 : u.features) == null ? void 0 : m[0]) ==
+        (v = (y = c == null ? void 0 : c.features) == null ? void 0 : y[0]) ==
         null
           ? void 0
-          : E.geometry;
+          : v.geometry;
     if (g) {
-      const w =
+      const _ =
           "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer/10/query",
-        b = new URLSearchParams({
+        A = new URLSearchParams({
           where: "1=1",
           geometry: JSON.stringify(g),
           geometryType: "esriGeometryPolygon",
@@ -2532,99 +1032,99 @@ async function us(e = {}, n = "") {
           returnGeometry: "false",
           f: "json",
         });
-      let R;
+      let b;
       try {
-        R = await fetch(w, {
+        b = await fetch(_, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: b.toString(),
-        }).then((G) => G.json());
+          body: A.toString(),
+        }).then((T) => T.json());
       } catch {
-        const G = `${w}?${b.toString()}`;
-        R = await fetch(G).then((Z) => Z.json());
+        const T = `${_}?${A.toString()}`;
+        b = await fetch(T).then((B) => B.json());
       }
-      const U = [],
+      const C = [],
         $ = [],
-        j = {};
-      for (const G of R.features || []) {
-        const Z = G.attributes || {};
-        let C = null;
+        P = {};
+      for (const T of b.features || []) {
+        const B = T.attributes || {};
+        let O = null;
         if (
-          (Z.NAME && ((C = Z.NAME.replace(/^Census Tract\s+/i, "")), U.push(C)),
-          Z.GEOID)
+          (B.NAME && ((O = B.NAME.replace(/^Census Tract\s+/i, "")), C.push(O)),
+          B.GEOID)
         ) {
-          const L = String(Z.GEOID);
-          ($.push(L), C && (j[L] = C));
+          const q = String(B.GEOID);
+          ($.push(q), O && (P[q] = O));
         }
       }
-      if (U.length || $.length) {
-        const G = Array.isArray(c.census_tracts)
-            ? c.census_tracts.map(String)
+      if (C.length || $.length) {
+        const T = Array.isArray(i.census_tracts)
+            ? i.census_tracts.map(String)
             : [],
-          Z = Array.isArray(c.census_tracts_fips)
-            ? c.census_tracts_fips.map(String)
+          B = Array.isArray(i.census_tracts_fips)
+            ? i.census_tracts_fips.map(String)
             : [],
-          C = c.census_tract_map || {};
-        (U.length && (c.census_tracts = [...new Set([...G, ...U])]),
-          $.length && (c.census_tracts_fips = [...new Set([...Z, ...$])]),
-          Object.keys(j).length && (c.census_tract_map = { ...C, ...j }));
+          O = i.census_tract_map || {};
+        (C.length && (i.census_tracts = [...new Set([...T, ...C])]),
+          $.length && (i.census_tracts_fips = [...new Set([...B, ...$])]),
+          Object.keys(P).length && (i.census_tract_map = { ...O, ...P }));
       }
     }
   } catch {}
-  let v = [];
-  (Array.isArray(c.census_tracts)
-    ? (v = c.census_tracts.map(String))
-    : typeof c.census_tracts == "string" &&
-      (v = c.census_tracts.split(/\s*,\s*/).filter(Boolean)),
-    l && v.unshift(String(l)),
-    (c.census_tracts = [...new Set(v)]));
-  let h = Array.isArray(c.census_tracts_fips)
-    ? c.census_tracts_fips.map(String)
+  let f = [];
+  (Array.isArray(i.census_tracts)
+    ? (f = i.census_tracts.map(String))
+    : typeof i.census_tracts == "string" &&
+      (f = i.census_tracts.split(/\s*,\s*/).filter(Boolean)),
+    l && f.unshift(String(l)),
+    (i.census_tracts = [...new Set(f)]));
+  let h = Array.isArray(i.census_tracts_fips)
+    ? i.census_tracts_fips.map(String)
     : [];
-  for (const _ of c.census_tracts)
-    if (/^\d{11}$/.test(_)) h.push(_);
-    else if (a && r) {
-      const u = String(_).replace(/[^0-9]/g, "");
-      if (u) {
-        const g = u.padStart(6, "0").slice(-6);
-        h.push(`${a}${r}${g}`);
+  for (const d of i.census_tracts)
+    if (/^\d{11}$/.test(d)) h.push(d);
+    else if (e && n) {
+      const c = String(d).replace(/[^0-9]/g, "");
+      if (c) {
+        const g = c.padStart(6, "0").slice(-6);
+        h.push(`${e}${n}${g}`);
       }
     }
   if (
-    (a && r && f && h.unshift(`${a}${r}${f}`),
-    (c.census_tracts_fips = [...new Set(h)]),
-    Array.isArray(c.census_tracts_fips) && c.census_tracts_fips.length)
+    (e && n && u && h.unshift(`${e}${n}${u}`),
+    (i.census_tracts_fips = [...new Set(h)]),
+    Array.isArray(i.census_tracts_fips) && i.census_tracts_fips.length)
   )
     try {
-      const _ = await wn(c.census_tracts_fips),
-        u = [];
-      for (const g of _) {
-        const w = (c.census_tract_map && c.census_tract_map[g]) || g;
-        u.push(w);
+      const d = await qt(i.census_tracts_fips),
+        c = [];
+      for (const g of d) {
+        const _ = (i.census_tract_map && i.census_tract_map[g]) || g;
+        c.push(_);
       }
-      if (((c.dac_tracts = u), (c.dac_tracts_fips = _), u.length)) {
-        const g = new Set([...(c.census_tracts || []), ...u]);
-        c.census_tracts = Array.from(g);
+      if (((i.dac_tracts = c), (i.dac_tracts_fips = d), c.length)) {
+        const g = new Set([...(i.census_tracts || []), ...c]);
+        i.census_tracts = Array.from(g);
       }
     } catch {}
-  if (Array.isArray(c.census_tracts_fips) && c.census_tracts_fips.length)
+  if (Array.isArray(i.census_tracts_fips) && i.census_tracts_fips.length)
     try {
-      const _ = await Ie(c.census_tracts_fips);
-      let u = 0,
+      const d = await kt(i.census_tracts_fips);
+      let c = 0,
         g = 0;
-      const w = new Set(c.dac_tracts_fips || []);
-      for (const b of c.census_tracts_fips) {
-        const R = _[b];
-        R &&
-          Number.isFinite(R.population) &&
-          ((u += R.population), w.has(String(b)) && (g += R.population));
+      const _ = new Set(i.dac_tracts_fips || []);
+      for (const A of i.census_tracts_fips) {
+        const b = d[A];
+        b &&
+          Number.isFinite(b.population) &&
+          ((c += b.population), _.has(String(A)) && (g += b.population));
       }
-      (u > 0 && (c.dac_population_pct = (g / u) * 100),
-        c.census_tracts_fips.length > 0 &&
-          (c.dac_tracts_pct = (w.size / c.census_tracts_fips.length) * 100));
+      (c > 0 && (i.dac_population_pct = (g / c) * 100),
+        i.census_tracts_fips.length > 0 &&
+          (i.dac_tracts_pct = (_.size / i.census_tracts_fips.length) * 100));
     } catch {}
   return (
-    (c.environment = {
+    (i.environment = {
       percentile: 48.5,
       overall_percentiles: {
         pollution_burden: 37.2,
@@ -2660,37 +1160,37 @@ async function us(e = {}, n = "") {
         housing_burden: 38.8,
       },
     }),
-    { ...e, water_district: c }
+    { ...t, water_district: i }
   );
 }
-async function ps(e = {}) {
+async function Le(t = {}) {
   var o, l;
-  const { lat: n, lon: s, english_less_than_very_well_pct: i } = e || {};
-  if (!Q(i) || n == null || s == null) return e;
+  const { lat: s, lon: r, english_less_than_very_well_pct: a } = t || {};
+  if (!R(a) || s == null || r == null) return t;
   try {
-    const a = await fetch(
-        `https://geo.fcc.gov/api/census/block/find?latitude=${n}&longitude=${s}&format=json`,
-      ).then((f) => f.json()),
-      r = (o = a == null ? void 0 : a.Block) == null ? void 0 : o.FIPS;
-    if (r && r.length >= 11) {
-      const f = r.slice(0, 2),
-        d = r.slice(2, 5),
-        y = `https://api.census.gov/data/2022/acs/acs5/profile?get=DP02_0111PE&for=tract:${r.slice(5, 11)}&in=state:${f}+county:${d}`,
-        v = await fetch(y).then((E) => E.json()),
-        h = (l = v == null ? void 0 : v[1]) == null ? void 0 : l[0],
-        m = Number(h);
-      if (Number.isFinite(m) && m >= 0)
-        return { ...e, english_less_than_very_well_pct: m };
+    const e = await fetch(
+        `https://geo.fcc.gov/api/census/block/find?latitude=${s}&longitude=${r}&format=json`,
+      ).then((u) => u.json()),
+      n = (o = e == null ? void 0 : e.Block) == null ? void 0 : o.FIPS;
+    if (n && n.length >= 11) {
+      const u = n.slice(0, 2),
+        p = n.slice(2, 5),
+        m = `https://api.census.gov/data/2022/acs/acs5/profile?get=DP02_0111PE&for=tract:${n.slice(5, 11)}&in=state:${u}+county:${p}`,
+        f = await fetch(m).then((v) => v.json()),
+        h = (l = f == null ? void 0 : f[1]) == null ? void 0 : l[0],
+        y = Number(h);
+      if (Number.isFinite(y) && y >= 0)
+        return { ...t, english_less_than_very_well_pct: y };
     }
   } catch {}
-  return e;
+  return t;
 }
-async function fs(e = {}) {
-  const { lat: n, lon: s } = e || {};
-  if (n == null || s == null) return { ...e, alerts: [] };
+async function Ie(t = {}) {
+  const { lat: s, lon: r } = t || {};
+  if (s == null || r == null) return { ...t, alerts: [] };
   try {
-    const i = `https://api.weather.gov/alerts/active?point=${n},${s}`,
-      o = await fetch(i, {
+    const a = `https://api.weather.gov/alerts/active?point=${s},${r}`,
+      o = await fetch(a, {
         headers: {
           Accept: "application/geo+json",
           "User-Agent": "CalWEP-Demographic-Website (info@calwep.org)",
@@ -2698,336 +1198,335 @@ async function fs(e = {}) {
       });
     if (!o.ok) throw new Error("NWS response not ok");
     const l = await o.json(),
-      a = Array.isArray(l == null ? void 0 : l.features)
+      e = Array.isArray(l == null ? void 0 : l.features)
         ? l.features
-            .map((r) => {
-              var f;
-              return (f = r == null ? void 0 : r.properties) == null
+            .map((n) => {
+              var u;
+              return (u = n == null ? void 0 : n.properties) == null
                 ? void 0
-                : f.headline;
+                : u.headline;
             })
             .filter(Boolean)
         : [];
-    return { ...e, alerts: a };
+    return { ...t, alerts: e };
   } catch {
-    return { ...e, alerts: [] };
+    return { ...t, alerts: [] };
   }
 }
-function St(e, n, s, i, o = "") {
-  const l = (a) => (a && String(a).trim() ? a : '<p class="note">No data</p>');
+function z(t, s, r, a, o = "") {
+  const l = (e) => (e && String(e).trim() ? e : `<p class="note">${et}</p>`);
   return `
     <section class="section-block">
-      <h3 class="section-header">${e}</h3>
+      <h3 class="section-header">${k(t)}</h3>
       ${o}
-      <div class="comparison-grid">
-        <div class="col local">${l(n)}</div>
-        <div class="col surrounding">${l(s)}</div>
-        <div class="col district">${l(i)}</div>
+      <div class="comparison-grid" role="table" aria-label="${k(t)}">
+        <div class="col local" role="cell" aria-label="Census tract">${l(s)}</div>
+        <div class="col surrounding" role="cell" aria-label="10-mile radius">${l(r)}</div>
+        <div class="col district" role="cell" aria-label="Water district">${l(a)}</div>
       </div>
     </section>
   `;
 }
-function cn(e, n, s) {
+function Ut(t, s, r) {
   const {
-      city: i,
+      city: a,
       zip: o,
       county: l,
-      census_tract: a,
-      lat: r,
-      lon: f,
-      english_less_than_very_well_pct: d,
-      language_other_than_english_pct: c,
-      spanish_at_home_pct: y,
-      languages: v,
+      census_tract: e,
+      lat: n,
+      lon: u,
+      english_less_than_very_well_pct: p,
+      language_other_than_english_pct: i,
+      spanish_at_home_pct: m,
+      languages: f,
       demographics: h = {},
-      dac_status: m,
-      environmental_hardships: E,
-      white_pct: _,
-      black_pct: u,
+      dac_status: y,
+      environmental_hardships: v,
+      white_pct: d,
+      black_pct: c,
       native_pct: g,
-      asian_pct: w,
-      pacific_pct: b,
-      other_race_pct: R,
-      two_or_more_races_pct: U,
+      asian_pct: _,
+      pacific_pct: A,
+      other_race_pct: b,
+      two_or_more_races_pct: C,
       hispanic_pct: $,
-      not_hispanic_pct: j,
-      owner_occupied_pct: G,
-      renter_occupied_pct: Z,
-      median_home_value: C,
-      high_school_or_higher_pct: L,
-      bachelors_or_higher_pct: Y,
-      alerts: ot,
-      enviroscreen: z,
-      surrounding_10_mile: at,
-      water_district: rt,
-    } = n || {},
-    ct = n.population ?? h.population,
-    lt = n.median_age ?? h.median_age,
-    Dt =
-      n.median_income ??
-      n.median_household_income ??
+      not_hispanic_pct: P,
+      owner_occupied_pct: T,
+      renter_occupied_pct: B,
+      median_home_value: O,
+      high_school_or_higher_pct: q,
+      bachelors_or_higher_pct: X,
+      alerts: E,
+      enviroscreen: D,
+      surrounding_10_mile: V,
+      water_district: U,
+    } = s || {},
+    G = s.population ?? h.population,
+    j = s.median_age ?? h.median_age,
+    H =
+      s.median_income ??
+      s.median_household_income ??
       h.median_income ??
       h.median_household_income,
-    F = n.per_capita_income ?? h.per_capita_income,
-    ae = n.poverty_rate ?? h.poverty_rate,
-    H = n.unemployment_rate ?? h.unemployment_rate,
-    re = Array.isArray(v) && v.length ? v : h.languages,
-    I = n.enviroscreen_score ?? (z == null ? void 0 : z.score),
-    bt = n.enviroscreen_percentile ?? (z == null ? void 0 : z.percentile),
-    Ot = Array.isArray(E) ? Array.from(new Set(E)) : [],
-    Bt = Array.isArray(ot) ? ot : [],
-    Wt =
-      r != null && f != null
-        ? `${Number(r).toFixed(6)}, ${Number(f).toFixed(6)}`
+    x = s.per_capita_income ?? h.per_capita_income,
+    ot = s.poverty_rate ?? h.poverty_rate,
+    Vt = s.unemployment_rate ?? h.unemployment_rate,
+    Jt = Array.isArray(f) && f.length ? f : h.languages,
+    Yt = s.enviroscreen_score ?? (D == null ? void 0 : D.score),
+    Xt = s.enviroscreen_percentile ?? (D == null ? void 0 : D.percentile),
+    Ct = Array.isArray(v) ? Array.from(new Set(v)) : [],
+    Nt = Array.isArray(E) ? E : [],
+    Zt =
+      n != null && u != null
+        ? `${Number(n).toFixed(6)}, ${Number(u).toFixed(6)}`
         : "—";
-  let Gt = "";
-  if (r != null && f != null) {
-    const S = new URL("/api/staticmap", window.location.origin);
-    (S.searchParams.set("lat", r),
-      S.searchParams.set("lon", f),
-      (Gt = `<img class="map-image" src="${S}" alt="Map of location" />`));
+  let Pt = "";
+  if (n != null && u != null) {
+    const w = new URL("/api/staticmap", window.location.origin);
+    (w.searchParams.set("lat", n),
+      w.searchParams.set("lon", u),
+      (Pt = `<img class="map-image" src="${w}" alt="Map of location" />`));
   }
-  const x = at || {},
-    D = rt || {},
-    Nt = Array.isArray(x.environmental_hardships)
-      ? Array.from(new Set(x.environmental_hardships))
+  const F = V || {},
+    N = U || {},
+    Dt = Array.isArray(F.environmental_hardships)
+      ? Array.from(new Set(F.environmental_hardships))
       : [],
-    dt = Array.isArray(D.environmental_hardships)
-      ? Array.from(new Set(D.environmental_hardships))
+    Ft = Array.isArray(N.environmental_hardships)
+      ? Array.from(new Set(N.environmental_hardships))
       : [],
-    zt = Array.isArray(x.census_tracts)
-      ? x.census_tracts.join(", ")
-      : k(x.census_tracts) || "—",
-    jt = Array.isArray(x.cities) ? x.cities.join(", ") : k(x.cities) || "—",
-    At = Array.isArray(D.census_tracts)
-      ? D.census_tracts.join(", ")
-      : k(D.census_tracts) || "—",
-    It = Array.isArray(D.cities) ? D.cities.join(", ") : k(D.cities) || "—",
-    Pt = `
+    Kt = Array.isArray(F.census_tracts)
+      ? F.census_tracts.join(", ")
+      : k(F.census_tracts) || "—",
+    Qt = Array.isArray(F.cities) ? F.cities.join(", ") : k(F.cities) || "—",
+    te = Array.isArray(N.census_tracts)
+      ? N.census_tracts.join(", ")
+      : k(N.census_tracts) || "—",
+    ee = Array.isArray(N.cities) ? N.cities.join(", ") : k(N.cities) || "—",
+    se = `
     <div class="kv">
-      <div class="key">City</div><div class="val">${k(i) || "—"}</div>
-      <div class="key">Census tract</div><div class="val">${k(a) || "—"}</div>
+      <div class="key">City</div><div class="val">${k(a) || "—"}</div>
+      <div class="key">Census tract</div><div class="val">${k(e) || "—"}</div>
       <div class="key">ZIP code</div><div class="val">${k(o) || "—"}</div>
       <div class="key">County</div><div class="val">${k(l) || "—"}</div>
-      <div class="key">Coordinates</div><div class="val">${Wt}</div>
+      <div class="key">Coordinates</div><div class="val">${Zt}</div>
     </div>
-    ${Gt}
+    ${Pt}
   `,
-    ce = `
+    ne = `
     <div class="kv">
-      <div class="key">Cities</div><div class="val">${jt}</div>
-      <div class="key">Census tracts</div><div class="val">${zt}</div>
+      <div class="key">Cities</div><div class="val">${Qt}</div>
+      <div class="key">Census tracts</div><div class="val">${Kt}</div>
     </div>
   `,
-    le = `
+    ie = `
     <div class="kv">
-      <div class="key">District</div><div class="val">${k(D.name) || "—"}</div>
-      <div class="key">Cities</div><div class="val">${It}</div>
-      <div class="key">Census tracts</div><div class="val">${At}</div>
+      <div class="key">District</div><div class="val">${k(N.name) || "—"}</div>
+      <div class="key">Cities</div><div class="val">${ee}</div>
+      <div class="key">Census tracts</div><div class="val">${te}</div>
     </div>
   `,
-    _e = St(
+    re = z(
       "Location Summary",
-      Pt,
-      ce,
-      le,
+      se,
+      ne,
+      ie,
       '<p class="section-description">This section lists basic geographic information for the census tract, surrounding 10&#8209;mile area, and water district, such as city, ZIP code, county, and coordinates.</p>',
     ),
-    Rt = (S = {}) =>
+    ct = (w = {}) =>
       `<div class="kv">${[
-        ["Total population", Jn(S.population)],
-        ["Median age", nn(S.median_age)],
+        ["Total population", Ae(w.population)],
+        ["Median age", Lt(w.median_age)],
         [
           "Median household income",
-          Ne(S.median_income ?? S.median_household_income),
+          bt(w.median_income ?? w.median_household_income),
         ],
-        ["Per capita income", Ne(S.per_capita_income)],
-        ["Poverty rate", M(S.poverty_rate)],
-        ["Unemployment rate", M(S.unemployment_rate)],
+        ["Per capita income", bt(w.per_capita_income)],
+        ["Poverty rate", S(w.poverty_rate)],
+        ["Unemployment rate", S(w.unemployment_rate)],
       ]
         .map(
-          ([B, X]) => `<div class="key">${B}</div><div class="val">${X}</div>`,
+          ([L, I]) => `<div class="key">${L}</div><div class="val">${I}</div>`,
         )
         .join("")}</div>`,
-    Ct = St(
+    ae = z(
       "Population &amp; Income (ACS)",
-      Rt({
-        population: ct,
-        median_age: lt,
-        median_income: Dt,
-        per_capita_income: F,
-        poverty_rate: ae,
-        unemployment_rate: H,
+      ct({
+        population: G,
+        median_age: j,
+        median_income: H,
+        per_capita_income: x,
+        poverty_rate: ot,
+        unemployment_rate: Vt,
       }),
-      Rt(x.demographics || {}),
-      Rt(D.demographics || {}),
+      ct(F.demographics || {}),
+      ct(N.demographics || {}),
       '<p class="section-description">This section provides a snapshot of the people living in the selected area, drawn from the American Community Survey (ACS). It includes the total population, median age, household income, poverty rate, and unemployment rate. These indicators offer a quick view of community size, economic stability, and social conditions.</p><p class="section-description"><em>Values for the surrounding 10-mile area and water district are population-weighted averages.</em></p>',
     ),
-    mt = (S = {}) =>
+    lt = (w = {}) =>
       `<div class="kv">${[
         [
           "Languages spoken",
-          Array.isArray(S.languages) && S.languages.length
-            ? S.languages.map((X) => k(X)).join(", ")
+          Array.isArray(w.languages) && w.languages.length
+            ? w.languages.map((I) => k(I)).join(", ")
             : "Not available",
         ],
         [
           "People who speak a language other than English at home",
-          M(S.language_other_than_english_pct),
+          S(w.language_other_than_english_pct),
         ],
         [
           'People who speak English less than "very well"',
-          M(S.english_less_than_very_well_pct),
+          S(w.english_less_than_very_well_pct),
         ],
-        ["People who speak Spanish at home", M(S.spanish_at_home_pct)],
+        ["People who speak Spanish at home", S(w.spanish_at_home_pct)],
       ]
         .map(
-          ([X, pt]) =>
-            `<div class="key">${X}</div><div class="val">${pt}</div>`,
+          ([I, Z]) => `<div class="key">${I}</div><div class="val">${Z}</div>`,
         )
         .join("")}</div>`,
-    vt = St(
+    oe = z(
       "Language (ACS)",
-      mt({
-        languages: re,
-        language_other_than_english_pct: c,
-        english_less_than_very_well_pct: d,
-        spanish_at_home_pct: y,
+      lt({
+        languages: Jt,
+        language_other_than_english_pct: i,
+        english_less_than_very_well_pct: p,
+        spanish_at_home_pct: m,
       }),
-      mt(x.demographics || {}),
-      mt(D.demographics || {}),
+      lt(F.demographics || {}),
+      lt(N.demographics || {}),
       '<p class="section-description">This section highlights the languages spoken in the community and key language indicators based on American Community Survey (ACS) 5&#8209;year estimates.</p><p class="section-description"><em>Values for the surrounding 10-mile area and water district are population-weighted averages.</em></p>',
     ),
-    kt = (S = {}) => {
-      const V = S.enviroscreen_score ?? S.score,
-        B = S.enviroscreen_percentile ?? S.percentile,
-        X = Number.isFinite(Number(B)) && Number(B) <= 1 ? Number(B) * 100 : B;
+    ut = (w = {}) => {
+      const W = w.enviroscreen_score ?? w.score,
+        L = w.enviroscreen_percentile ?? w.percentile,
+        I = Number.isFinite(Number(L)) && Number(L) <= 1 ? Number(L) * 100 : L;
       return `<div class="kv">${[
-        ["Score", nn(V)],
-        ["Percentile", M(X)],
+        ["Score", Lt(W)],
+        ["Percentile", S(I)],
       ]
         .map(
-          ([qt, Lt]) =>
-            `<div class="key">${qt}</div><div class="val">${Lt}</div>`,
+          ([mt, K]) =>
+            `<div class="key">${mt}</div><div class="val">${K}</div>`,
         )
         .join("")}</div>`;
     },
-    ue = St(
+    ce = z(
       "EnviroScreen (CalEnviroScreen 4.0)",
-      kt({ enviroscreen_score: I, enviroscreen_percentile: bt }),
-      kt(x.environment || {}),
-      kt(D.environment || {}),
+      ut({ enviroscreen_score: Yt, enviroscreen_percentile: Xt }),
+      ut(F.environment || {}),
+      ut(N.environment || {}),
       '<p class="section-description">This section shows the CalEnviroScreen 4.0 score and percentile for the selected area and comparison regions.</p>',
     ),
-    Mt = (S = {}) =>
+    pt = (w = {}) =>
       `<div class="kv">${[
-        ["White", M(S.white_pct)],
-        ["Black or African American", M(S.black_pct)],
-        ["American Indian / Alaska Native", M(S.native_pct)],
-        ["Asian", M(S.asian_pct)],
-        ["Native Hawaiian / Pacific Islander", M(S.pacific_pct)],
-        ["Other race", M(S.other_race_pct)],
-        ["Two or more races", M(S.two_or_more_races_pct)],
-        ["Hispanic", M(S.hispanic_pct)],
-        ["Not Hispanic", M(S.not_hispanic_pct)],
+        ["White", S(w.white_pct)],
+        ["Black or African American", S(w.black_pct)],
+        ["American Indian / Alaska Native", S(w.native_pct)],
+        ["Asian", S(w.asian_pct)],
+        ["Native Hawaiian / Pacific Islander", S(w.pacific_pct)],
+        ["Other race", S(w.other_race_pct)],
+        ["Two or more races", S(w.two_or_more_races_pct)],
+        ["Hispanic", S(w.hispanic_pct)],
+        ["Not Hispanic", S(w.not_hispanic_pct)],
       ]
         .map(
-          ([B, X]) => `<div class="key">${B}</div><div class="val">${X}</div>`,
+          ([L, I]) => `<div class="key">${L}</div><div class="val">${I}</div>`,
         )
         .join("")}</div>`,
-    Yt = St(
+    le = z(
       "Race &amp; Ethnicity (ACS)",
-      Mt({
-        white_pct: _,
-        black_pct: u,
+      pt({
+        white_pct: d,
+        black_pct: c,
         native_pct: g,
-        asian_pct: w,
-        pacific_pct: b,
-        other_race_pct: R,
-        two_or_more_races_pct: U,
+        asian_pct: _,
+        pacific_pct: A,
+        other_race_pct: b,
+        two_or_more_races_pct: C,
         hispanic_pct: $,
-        not_hispanic_pct: j,
+        not_hispanic_pct: P,
       }),
-      Mt(x.demographics || {}),
-      Mt(D.demographics || {}),
+      pt(F.demographics || {}),
+      pt(N.demographics || {}),
       '<p class="section-description">This section shows the racial and ethnic composition of the community, expressed as percentages of the total population using American Community Survey (ACS) data. These insights help identify the diversity of the area and support efforts to ensure programs, outreach, and engagement strategies reflect and serve all community groups.</p><p class="section-description"><em>Values for the surrounding 10-mile area and water district are population-weighted averages.</em></p>',
     ),
-    $t = (S = {}) =>
+    dt = (w = {}) =>
       `<div class="kv">${[
-        ["Owner occupied", M(S.owner_occupied_pct)],
-        ["Renter occupied", M(S.renter_occupied_pct)],
-        ["Median home value", Ne(S.median_home_value)],
-        ["High school or higher", M(S.high_school_or_higher_pct)],
-        ["Bachelor's degree or higher", M(S.bachelors_or_higher_pct)],
+        ["Owner occupied", S(w.owner_occupied_pct)],
+        ["Renter occupied", S(w.renter_occupied_pct)],
+        ["Median home value", bt(w.median_home_value)],
+        ["High school or higher", S(w.high_school_or_higher_pct)],
+        ["Bachelor's degree or higher", S(w.bachelors_or_higher_pct)],
       ]
         .map(
-          ([B, X]) => `<div class="key">${B}</div><div class="val">${X}</div>`,
+          ([L, I]) => `<div class="key">${L}</div><div class="val">${I}</div>`,
         )
         .join("")}</div>`,
-    Ft = St(
+    ue = z(
       "Housing &amp; Education (ACS)",
-      $t({
-        owner_occupied_pct: G,
-        renter_occupied_pct: Z,
-        median_home_value: C,
-        high_school_or_higher_pct: L,
-        bachelors_or_higher_pct: Y,
+      dt({
+        owner_occupied_pct: T,
+        renter_occupied_pct: B,
+        median_home_value: O,
+        high_school_or_higher_pct: q,
+        bachelors_or_higher_pct: X,
       }),
-      $t(x.demographics || {}),
-      $t(D.demographics || {}),
+      dt(F.demographics || {}),
+      dt(N.demographics || {}),
       '<p class="section-description">This section combines information on housing and educational attainment in the community. It includes the percentage of owner&#8209;occupied and renter&#8209;occupied homes, median home value, and levels of education such as high school completion and bachelor’s degree or higher. These indicators provide insight into community stability, affordability, and educational opportunities, helping inform outreach strategies and program planning.</p><p class="section-description"><em>Values for the surrounding 10-mile area and water district are population-weighted averages.</em></p>',
     ),
-    Et = (S, V, B, X) => {
-      const pt = Array.isArray(V) ? V.length > 0 : !!S,
-        qt = pt ? "var(--success)" : "var(--border-strong)",
-        Lt = [`Disadvantaged community: <strong>${pt ? "Yes" : "No"}</strong>`],
-        P = [];
+    ht = (w, W, L, I) => {
+      const Z = Array.isArray(W) ? W.length > 0 : !!w,
+        mt = Z ? "var(--success)" : "var(--border-strong)",
+        K = [`Disadvantaged community: <strong>${Z ? "Yes" : "No"}</strong>`],
+        nt = [];
       return (
-        Number.isFinite(B) &&
-          P.push(`<li><strong>${M(B)}</strong> of population</li>`),
-        Number.isFinite(X) &&
-          P.push(`<li><strong>${M(X)}</strong> of tracts</li>`),
-        P.length && Lt.push(`<ul class="dac-stats">${P.join("")}</ul>`),
-        Array.isArray(V) &&
-          V.length &&
-          Lt.push(
-            `<div class="dac-tracts">Tracts ${V.map((Tt) => k(Tt)).join(", ")}</div>`,
+        Number.isFinite(L) &&
+          nt.push(`<li><strong>${S(L)}</strong> of population</li>`),
+        Number.isFinite(I) &&
+          nt.push(`<li><strong>${S(I)}</strong> of tracts</li>`),
+        nt.length && K.push(`<ul class="dac-stats">${nt.join("")}</ul>`),
+        Array.isArray(W) &&
+          W.length &&
+          K.push(
+            `<div class="dac-tracts">Tracts ${W.map((_e) => k(_e)).join(", ")}</div>`,
           ),
-        `<div class="callout" style="border-left-color:${qt}">${Lt.join("")}</div>`
+        `<div class="callout" style="border-left-color:${mt}">${K.join("")}</div>`
       );
     },
-    ut = St(
+    pe = z(
       "Disadvantaged Community (DAC) Status",
-      Et(m),
-      Array.isArray(x.dac_tracts)
-        ? Et(null, x.dac_tracts, x.dac_population_pct, x.dac_tracts_pct)
+      ht(y),
+      Array.isArray(F.dac_tracts)
+        ? ht(null, F.dac_tracts, F.dac_population_pct, F.dac_tracts_pct)
         : "",
-      Array.isArray(D.dac_tracts)
-        ? Et(null, D.dac_tracts, D.dac_population_pct, D.dac_tracts_pct)
+      Array.isArray(N.dac_tracts)
+        ? ht(null, N.dac_tracts, N.dac_population_pct, N.dac_tracts_pct)
         : "",
       '<p class="section-description">This section indicates whether the selected area is designated as a Disadvantaged Community (DAC) using the California Department of Water Resources (DWR) mapping tool. DAC status is determined by household income and is shown as a simple yes/no outcome. This designation is important for identifying areas eligible for certain state and federal funding opportunities and for ensuring that equity considerations are included in outreach and program planning.</p>',
     ),
-    wt = St(
+    de = z(
       "Environmental Hardships",
-      Ot.length
-        ? `<div class="stats">${Ot.map((S) => `<span class="pill">${k(S)}</span>`).join("")}</div>`
+      Ct.length
+        ? `<div class="stats">${Ct.map((w) => `<span class="pill">${k(w)}</span>`).join("")}</div>`
         : "",
-      Nt.length
-        ? `<div class="stats">${Nt.map((S) => `<span class="pill">${k(S)}</span>`).join("")}</div>`
+      Dt.length
+        ? `<div class="stats">${Dt.map((w) => `<span class="pill">${k(w)}</span>`).join("")}</div>`
         : "",
-      dt.length
-        ? `<div class="stats">${dt.map((S) => `<span class="pill">${k(S)}</span>`).join("")}</div>`
+      Ft.length
+        ? `<div class="stats">${Ft.map((w) => `<span class="pill">${k(w)}</span>`).join("")}</div>`
         : "",
       '<p class="section-description">This section lists environmental hardships reported for the selected location, highlighting challenges that may affect residents and program planning.</p>',
     ),
-    Vt = `
+    he = `
     <section class="section-block">
       <h3 class="section-header">Active Alerts (National Weather Service)</h3>
       <p class="section-description">This section displays any current weather alerts issued by the National Weather Service (NWS) for the selected location. Alerts may include warnings for extreme heat, flooding, wildfire smoke, or other hazardous conditions. Having this information alongside demographic and environmental data helps staff anticipate safety concerns for events, tailor outreach, and ensure programs are responsive to current community conditions.</p>
-      ${Bt.length ? `<div class="stats">${Bt.map((S) => `<span class="pill">${k(S)}</span>`).join("")}</div>` : '<p class="note">No active alerts found for this location.</p>'}
+      ${Nt.length ? `<div class="stats">${Nt.map((w) => `<span class="pill">${k(w)}</span>`).join("")}</div>` : '<p class="note">No active alerts found for this location.</p>'}
     </section>
   `,
-    Xt = `
+    me = `
     <div class="comparison-grid column-headers">
       <div class="col">Census tract</div>
       <div class="col">10 mile radius</div>
@@ -3038,7 +1537,7 @@ function cn(e, n, s) {
     <article class="card">
       <div class="card__header">
         <div class="card__head-left">
-          <h2 class="card__title">Results for: ${k(e)}</h2>
+          <h2 class="card__title">Results for: ${k(t)}</h2>
           <div class="card__actions">
             <button type="button" id="printBtn">Print</button>
             <button type="button" id="pdfBtn">Download PDF</button>
@@ -3046,102 +1545,106 @@ function cn(e, n, s) {
             <button type="button" id="shareBtn">Share Link</button>
           </div>
         </div>
-        <span class="updated">Updated ${Oe()}</span>
+        <span class="updated">Updated ${ye()}</span>
       </div>
-      ${Xt}
-      ${_e}
-      ${Ct}
-      ${vt}
-      ${Yt}
-      ${Ft}
-      ${ut}
+      ${me}
+      ${re}
+      ${ae}
+      ${oe}
+      ${le}
       ${ue}
-      ${wt}
-      ${Vt}
-      <p class="note">Search took ${gn(s)}.</p>
+      ${pe}
+      ${ce}
+      ${de}
+      ${he}
+      <p class="note">Search took ${ve(r)}.</p>
       <p class="note">Values for the surrounding 10-mile area and water district are population-weighted averages.</p>
       <span class="updated--footer">
         Sources: FCC Block for county &amp; tract; US Census ACS 5‑year (languages, population, median income); CalEnviroScreen 4.0; NWS alerts.
       </span>
     </article>
     `)),
-    Zn());
+    we());
 }
-async function Tn() {
-  const e = document.getElementById("autocomplete"),
-    n = document.getElementById("result"),
-    s = ((e == null ? void 0 : e.value) || "").trim();
-  if (s.length < 4) {
-    tn("Please enter a more complete address (at least 4 characters).", s, 0);
+async function $t() {
+  const t = document.getElementById("autocomplete"),
+    s = document.getElementById("result"),
+    r = ((t == null ? void 0 : t.value) || "").trim();
+  if (r.length < 4) {
+    Tt("Please enter a more complete address (at least 4 characters).", r, 0);
     return;
   }
-  const i = s.toLowerCase();
-  if (be.has(i)) {
-    const a = be.get(i);
-    Ut = { address: s, data: a };
-    const r = new URL(window.location);
-    (r.searchParams.set("address", s),
-      window.history.replaceState(null, "", r.toString()),
-      cn(s, a, 0));
+  const a = r.toLowerCase();
+  if (_t.has(a)) {
+    const e = _t.get(a);
+    J = { address: r, data: e };
+    const n = new URL(window.location);
+    (n.searchParams.set("address", r),
+      window.history.replaceState(null, "", n.toString()),
+      Ut(r, e, 0));
     return;
   }
-  (n.setAttribute("aria-busy", "true"), Kn(s));
+  (s.setAttribute("aria-busy", "true"), fe(r));
   const o = document.getElementById("spinnerOverlay");
-  (o && (o.style.display = "flex"), Qn());
+  (o && (o.style.display = "flex"), be());
   let l = 0;
   try {
-    const a = he("/lookup", { address: s });
-    console.log("Lookup request:", a);
-    let r = await ie(a);
-    if (!r || typeof r != "object") throw new Error("Malformed response.");
-    r = await st("enrichLocation", () => ts(r));
-    const [f, d, c, y, v] = await Promise.all([
-      st("fetchLanguageAcs", () => es(r)),
-      st("enrichSurrounding", () => ls(r)),
-      st("enrichWaterDistrict", () => us(r, s)),
-      st("enrichEnglishProficiency", () => ps(r)),
-      st("enrichNwsAlerts", () => fs(r)),
+    const e = at("/lookup", { address: r });
+    console.log("Lookup request:", e);
+    let n = await tt(e);
+    if (!n || typeof n != "object") throw new Error("Malformed response.");
+    n = await M("enrichLocation", () => Se(n));
+    const [u, p, i, m, f] = await Promise.all([
+      M("fetchLanguageAcs", () => $e(n)),
+      M("enrichSurrounding", () => Te(n)),
+      M("enrichWaterDistrict", () => Re(n, r)),
+      M("enrichEnglishProficiency", () => Le(n)),
+      M("enrichNwsAlerts", () => Ie(n)),
     ]);
-    se(r, f, d, c, y, v);
-    const h = await st("enrichTractDemographics", () => ss(r));
-    se(r, h);
-    const m = await st("enrichRegionBasics", () => is(r)),
-      E = await st("enrichRegionHousingEducation", () => os(r));
-    se(r, m, E);
-    const [_, u, g] = await Promise.all([
-      st("enrichRegionLanguages", () => rs(r)),
-      st("enrichRegionHardships", () => cs(r)),
-      st("enrichUnemployment", () => as(r)),
+    it(n, u, p, i, m, f);
+    const h = await M("enrichTractDemographics", () => ke(n));
+    it(n, h);
+    const y = await M("enrichRegionBasics", () => Ce(n)),
+      v = await M("enrichRegionHousingEducation", () => Ne(n));
+    it(n, y, v);
+    const [d, c, g] = await Promise.all([
+      M("enrichRegionLanguages", () => De(n)),
+      M("enrichRegionHardships", () => Fe(n)),
+      M("enrichUnemployment", () => Pe(n)),
     ]);
-    (se(r, _, u, g), (Ut = { address: s, data: r }), be.set(i, r));
-    const w = new URL(window.location);
-    (w.searchParams.set("address", s),
-      window.history.replaceState(null, "", w.toString()),
-      (l = sn()),
-      cn(s, r, l));
-  } catch (a) {
-    (l || (l = sn()), tn(String(a), s, l));
+    (it(n, d, c, g), (J = { address: r, data: n }), _t.set(a, n));
+    const _ = new URL(window.location);
+    (_.searchParams.set("address", r),
+      window.history.replaceState(null, "", _.toString()),
+      (l = It()),
+      Ut(r, n, l));
+  } catch (e) {
+    (l || (l = It()), Tt(String(e), r, l));
   } finally {
-    const a = document.getElementById("spinnerOverlay");
-    (a && (a.style.display = "none"), n.removeAttribute("aria-busy"));
+    const e = document.getElementById("spinnerOverlay");
+    (e && (e.style.display = "none"), s.removeAttribute("aria-busy"));
   }
 }
-function ds() {
-  const e = document.getElementById("lookupBtn");
-  if (!e) return;
-  const n = e.cloneNode(!0);
-  (e.replaceWith(n),
-    n.addEventListener("click", (s) => {
-      (s.preventDefault(), Tn().catch(console.error));
+function Be() {
+  const t = document.getElementById("lookupBtn");
+  if (!t) return;
+  const s = t.cloneNode(!0);
+  (t.replaceWith(s),
+    s.addEventListener("click", (a) => {
+      (a.preventDefault(), $t().catch(console.error));
     }));
+  const r = document.getElementById("lookupForm");
+  r == null ||
+    r.addEventListener("submit", (a) => {
+      (a.preventDefault(), $t().catch(console.error));
+    });
 }
-En().catch(() => {});
+zt().catch(() => {});
 window.onload = () => {
-  (Cn(), ds());
-  const n = new URLSearchParams(window.location.search).get("address");
-  if (n) {
-    const s = document.getElementById("autocomplete");
-    s && ((s.value = n), Tn().catch(console.error));
+  (ge(), Be());
+  const s = new URLSearchParams(window.location.search).get("address");
+  if (s) {
+    const r = document.getElementById("autocomplete");
+    r && ((r.value = s), $t().catch(console.error));
   }
 };
-export { _s as p };

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
           </ol>
         </div>
 
-        <div class="controls">
+        <form id="lookupForm" class="controls" role="search" aria-label="Address lookup">
           <label class="visually-hidden" for="autocomplete"
             >Search address</label
           >
@@ -76,10 +76,10 @@
               aria-label="Address search"
             />
             <ul id="autocomplete-list" class="autocomplete-list"></ul>
-            <button id="lookupBtn" type="button" aria-label="Lookup demographics">
+            <button id="lookupBtn" type="submit" aria-label="Lookup demographics">
             Lookup
           </button>
-        </div>
+        </form>
       </header>
 
       <main id="main-content" class="main-column stack stack--xxl">


### PR DESCRIPTION
## Summary
- Replace generic "Not available" with consistent "No data available" messaging and ensure comparison sections render when data is missing
- Wrap address lookup in a semantic search form and enhance comparison grid with ARIA roles for accessibility
- Add graceful fallback in Enviroscreen section and hook form submission to lookup logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac51274adc8327b3c47f0391854deb