### PR TITLE
Populate local housing and education stats

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -865,15 +865,22 @@ async function enrichTractDemographics(data = {}) {
     "two_or_more_races_pct",
     "hispanic_pct",
     "not_hispanic_pct",
+    "owner_occupied_pct",
+    "renter_occupied_pct",
+    "median_home_value",
+    "high_school_or_higher_pct",
+    "bachelors_or_higher_pct",
   ];
   const needsData = localFips && fields.some((k) => isMissing(data[k]));
   if (!needsData) return data;
   const lookup = await fetchTractDemographics([localFips]);
   const info = lookup[localFips];
   if (!info) return data;
+  const housingEdu = await aggregateHousingEducationForTracts([localFips]);
+  const merged = { ...info, ...housingEdu };
   const out = { ...data };
-  out.demographics = { ...out.demographics, ...info };
-  for (const [k, v] of Object.entries(info)) {
+  out.demographics = { ...out.demographics, ...merged };
+  for (const [k, v] of Object.entries(merged)) {
     if (isMissing(out[k])) out[k] = v;
   }
   return out;


### PR DESCRIPTION
## Summary
- ensure `enrichTractDemographics` fetches housing and education data for the main census tract
- merge owner/renter occupancy, median home value, and education levels into the primary result

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac966ef49c8327aba7a6079705a102