### PR TITLE
Allow wildcard CORS and proxy API requests

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,7 +64,9 @@ function shareReport() {
 }
 
 // ---------- Config ----------
-const API_BASE = "https://nftapi.cyberwiz.io";
+const API_BASE =
+  document.querySelector('meta[name="api-base"]')?.content ||
+  window.location.origin;
 const API_PATH = "/demographics"; // see section 2 for why '/api' is safest
 
 // ---------- Utilities ----------

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const app = express();
+
+const ALLOWED_ORIGINS = [/\.calwep\.org$/i, /\.cyberwiz\.io$/i];
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin) {
+    try {
+      const hostname = new URL(origin).hostname;
+      if (ALLOWED_ORIGINS.some((re) => re.test(hostname))) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Vary', 'Origin');
+        res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      }
+    } catch (err) {
+      // ignore invalid origin
+    }
+  }
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
+app.use(async (req, res) => {
+  const target = `https://nftapi.cyberwiz.io${req.originalUrl}`;
+  try {
+    const upstream = await fetch(target);
+    const body = await upstream.text();
+    upstream.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    res.status(upstream.status).send(body);
+  } catch (err) {
+    res.status(502).json({ error: 'Proxy error', details: String(err) });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`CORS proxy listening on ${port}`);
+});


### PR DESCRIPTION
## Summary
- Proxy API requests through local server with CORS headers for `*.calwep.org` and `*.cyberwiz.io`
- Read API base from `<meta name="api-base">` or default to current origin

## Testing
- `node server.js &` then `curl -I -H "Origin: https://demo.calwep.org" "http://localhost:3000/lookup?address=Test"`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acb0bfffcc8327a98798c34021e309